### PR TITLE
feat: commit default value (--commit)

### DIFF
--- a/src/commands/apply-migrations.command.ts
+++ b/src/commands/apply-migrations.command.ts
@@ -133,7 +133,7 @@ export class ApplyMigrationsCommand extends BaseCommand {
   @Option({
     flags: '-c, --commit [boolean]',
     description: 'Create a revision after applying migrations',
-    defaultValue: false,
+    defaultValue: true,
   })
   parseCommit(value?: string): boolean {
     return JSON.parse(value ?? 'false') as boolean;

--- a/src/commands/upload-rows.command.ts
+++ b/src/commands/upload-rows.command.ts
@@ -419,7 +419,7 @@ export class UploadRowsCommand extends BaseCommand {
   @Option({
     flags: '-c, --commit [boolean]',
     description: 'Create a revision after uploading rows',
-    defaultValue: false,
+    defaultValue: true,
   })
   parseCommit(value?: string) {
     return JSON.parse(value ?? 'false') as boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now commits revisions by default after applying migrations and after uploading rows.
  * The -c/--commit flag defaults to true; pass --commit false to skip committing.
  * Behavior is otherwise unchanged, and explicit values for --commit are still respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->