### PR TITLE
fix: commit flag

### DIFF
--- a/src/commands/__tests__/apply-migrations.command.spec.ts
+++ b/src/commands/__tests__/apply-migrations.command.spec.ts
@@ -268,7 +268,7 @@ describe('ApplyMigrationsCommand', () => {
   it('parses commit option correctly', () => {
     expect(command.parseCommit('true')).toBe(true);
     expect(command.parseCommit('false')).toBe(false);
-    expect(command.parseCommit()).toBe(false);
+    expect(command.parseCommit()).toBe(true);
   });
 
   describe('with commit option', () => {

--- a/src/commands/__tests__/upload-rows.command.spec.ts
+++ b/src/commands/__tests__/upload-rows.command.spec.ts
@@ -605,7 +605,7 @@ describe('UploadRowsCommand', () => {
   it('parses commit option correctly', () => {
     expect(command.parseCommit('true')).toBe(true);
     expect(command.parseCommit('false')).toBe(false);
-    expect(command.parseCommit()).toBe(false);
+    expect(command.parseCommit()).toBe(true);
   });
 
   describe('with commit option', () => {

--- a/src/commands/apply-migrations.command.ts
+++ b/src/commands/apply-migrations.command.ts
@@ -133,9 +133,8 @@ export class ApplyMigrationsCommand extends BaseCommand {
   @Option({
     flags: '-c, --commit [boolean]',
     description: 'Create a revision after applying migrations',
-    defaultValue: true,
   })
   parseCommit(value?: string): boolean {
-    return JSON.parse(value ?? 'false') as boolean;
+    return JSON.parse(value ?? 'true') as boolean;
   }
 }

--- a/src/commands/upload-rows.command.ts
+++ b/src/commands/upload-rows.command.ts
@@ -419,9 +419,8 @@ export class UploadRowsCommand extends BaseCommand {
   @Option({
     flags: '-c, --commit [boolean]',
     description: 'Create a revision after uploading rows',
-    defaultValue: true,
   })
   parseCommit(value?: string) {
-    return JSON.parse(value ?? 'false') as boolean;
+    return JSON.parse(value ?? 'true') as boolean;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Apply Migrations and Upload Rows now commit by default when the --commit flag is omitted, automatically creating a revision. Use --commit=false to skip committing.
- Tests
  - Updated test expectations to align with the new default commit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->