### PR TITLE
feat: X-Api-Key header auth

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -24,17 +24,20 @@ revisium schema save --folder ./schemas --url revisium://cloud.revisium.io/org/p
 
 ## API Key Authentication
 
-API key for automated access (future feature).
+API key for automated and programmatic access. Keys use the `rev_` prefix and are sent via the `X-Api-Key` header (recommended over Bearer for API keys).
 
 ### Usage
 
 ```bash
 # In URL query parameter
-revisium://cloud.revisium.io/org/proj?apikey=ak_xxx...
+revisium://cloud.revisium.io/org/proj?apikey=rev_xxxxxxxxxxxxxxxxxxxx
 
 # Via environment variable
-export REVISIUM_API_KEY=ak_xxx...
+export REVISIUM_API_KEY=rev_xxxxxxxxxxxxxxxxxxxx
 ```
+
+**Personal keys** are linked to a user account — `me()` returns the key owner.
+**Service keys** are not linked to a user — the CLI displays "service account" instead of a username.
 
 ## Password Authentication
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
-        "@revisium/client": "^0.4.0",
+        "@revisium/client": "^0.5.0",
         "@revisium/schema-toolkit": "^0.4.1",
         "@types/object-hash": "^3.0.6",
         "ajv": "^8.18.0",
@@ -223,7 +223,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -795,8 +794,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -3439,7 +3437,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.5.tgz",
       "integrity": "sha512-DQpWdr3ShO0BHWkHl3I4W/jR6R3pDtxyBlmrpTuZF+PXxQyBXNvsUne0Wyo6QHPEDi+pAz9XchBFoKbqOhcdTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -3499,7 +3496,6 @@
       "integrity": "sha512-Qr25MEY9t8VsMETy7eXQ0cNXqu0lzuFrrTr+f+1G57ABCtV5Pogm7n9bF71OU2bnkDD32Bi4hQLeFR90cku3Tw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3541,7 +3537,6 @@
       "integrity": "sha512-o7KNZlJJe+6Qo/GdUeofIgrUINzSVYkl3UZ5px+e+fHhftDfx+W41QuKu+EXPkOm02R6qApDFp3UeIyJrBdS9g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.8.1"
@@ -3600,7 +3595,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.16.tgz",
       "integrity": "sha512-IOegr5+ZfUiMKgk+garsSU4MOkPRhm46e6w8Bp1GcO4vCdl9Piz6FlWAzKVfa/U3Hn/DdzSVJOW3TWcQQFdBDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3959,9 +3953,9 @@
       }
     },
     "node_modules/@revisium/client": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@revisium/client/-/client-0.4.0.tgz",
-      "integrity": "sha512-fhRUawJtDIIrMbFspS3WLwJh6DitNSpCuT+NSv5G+RpjXTUUPRuNBuWK/lJrWFtUzMiLoqp9gsrEKw2I5/n42A==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@revisium/client/-/client-0.5.0.tgz",
+      "integrity": "sha512-z3Yks0zwcgKlYENToyj197/gd+kQXeVF/NxwndtLjuJw1ECjr1/UrlFugf0IDYp8f5TWJp2Ur/983W+fEyDkUg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -4070,7 +4064,6 @@
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -4143,7 +4136,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.23"
@@ -4506,7 +4498,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4654,7 +4645,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4749,6 +4739,7 @@
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
       "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4816,7 +4807,6 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -5380,7 +5370,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5443,7 +5432,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5989,7 +5977,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6342,7 +6329,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6802,7 +6788,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7296,7 +7283,6 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7358,7 +7344,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8729,7 +8714,6 @@
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9301,7 +9285,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10678,7 +10661,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -10798,7 +10780,6 @@
       "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.2",
@@ -11431,7 +11412,6 @@
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -11725,7 +11705,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12349,7 +12328,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -12385,7 +12363,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -12412,7 +12391,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13578,7 +13556,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -13735,7 +13712,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13982,7 +13958,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
-    "@revisium/client": "^0.4.0",
+    "@revisium/client": "^0.5.0",
     "@revisium/schema-toolkit": "^0.4.1",
     "@types/object-hash": "^3.0.6",
     "ajv": "^8.18.0",

--- a/src/services/connection/__tests__/api-client.spec.ts
+++ b/src/services/connection/__tests__/api-client.spec.ts
@@ -1,0 +1,137 @@
+import type { MeModel } from '@revisium/client';
+import { RevisiumApiClient } from '../api-client';
+import type { AuthCredentials } from '../../url';
+
+describe('RevisiumApiClient', () => {
+  let apiClient: RevisiumApiClient;
+
+  beforeEach(() => {
+    apiClient = new RevisiumApiClient('http://localhost:8080');
+  });
+
+  describe('authenticateWithApiKey (via authenticate)', () => {
+    it('calls loginWithApiKey on the underlying client', async () => {
+      const loginWithApiKeySpy = jest
+        .spyOn(apiClient.client, 'loginWithApiKey')
+        .mockImplementation(() => {});
+      const meSpy = jest
+        .spyOn(apiClient.client, 'me')
+        .mockResolvedValue({ username: 'key-owner' } as MeModel);
+
+      const result = await apiClient.authenticate({
+        method: 'apikey',
+        apikey: 'rev_test_key',
+      });
+
+      expect(loginWithApiKeySpy).toHaveBeenCalledWith('rev_test_key');
+      expect(meSpy).toHaveBeenCalled();
+      expect(result).toBe('key-owner');
+    });
+
+    it('does not call loginWithToken for apikey auth', async () => {
+      const loginWithTokenSpy = jest.spyOn(apiClient.client, 'loginWithToken');
+      jest
+        .spyOn(apiClient.client, 'loginWithApiKey')
+        .mockImplementation(() => {});
+      jest
+        .spyOn(apiClient.client, 'me')
+        .mockResolvedValue({ username: 'user' } as MeModel);
+
+      await apiClient.authenticate({
+        method: 'apikey',
+        apikey: 'rev_test_key',
+      });
+
+      expect(loginWithTokenSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns "service account" when me() fails (service key)', async () => {
+      jest
+        .spyOn(apiClient.client, 'loginWithApiKey')
+        .mockImplementation(() => {});
+      jest
+        .spyOn(apiClient.client, 'me')
+        .mockRejectedValue(new Error('Unauthorized'));
+
+      const result = await apiClient.authenticate({
+        method: 'apikey',
+        apikey: 'rev_service_key',
+      });
+
+      expect(result).toBe('service account');
+    });
+
+    it('returns "authenticated user" when me() returns empty username', async () => {
+      jest
+        .spyOn(apiClient.client, 'loginWithApiKey')
+        .mockImplementation(() => {});
+      jest
+        .spyOn(apiClient.client, 'me')
+        .mockResolvedValue({ username: '' } as MeModel);
+
+      const result = await apiClient.authenticate({
+        method: 'apikey',
+        apikey: 'rev_test_key',
+      });
+
+      expect(result).toBe('authenticated user');
+    });
+  });
+
+  describe('authenticateWithToken (via authenticate)', () => {
+    it('calls loginWithToken on the underlying client', async () => {
+      const loginWithTokenSpy = jest
+        .spyOn(apiClient.client, 'loginWithToken')
+        .mockImplementation(() => {});
+      jest
+        .spyOn(apiClient.client, 'me')
+        .mockResolvedValue({ username: 'token-user' } as MeModel);
+
+      const result = await apiClient.authenticate({
+        method: 'token',
+        token: 'jwt-token-123',
+      });
+
+      expect(loginWithTokenSpy).toHaveBeenCalledWith('jwt-token-123');
+      expect(result).toBe('token-user');
+    });
+
+    it('does not call loginWithApiKey for token auth', async () => {
+      jest
+        .spyOn(apiClient.client, 'loginWithToken')
+        .mockImplementation(() => {});
+      const loginWithApiKeySpy = jest.spyOn(
+        apiClient.client,
+        'loginWithApiKey',
+      );
+      jest
+        .spyOn(apiClient.client, 'me')
+        .mockResolvedValue({ username: 'user' } as MeModel);
+
+      await apiClient.authenticate({
+        method: 'token',
+        token: 'jwt-token-123',
+      });
+
+      expect(loginWithApiKeySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('authenticate validation', () => {
+    it('throws when token method has no token', async () => {
+      await expect(
+        apiClient.authenticate({
+          method: 'token',
+        } as AuthCredentials),
+      ).rejects.toThrow('Token is required for token authentication');
+    });
+
+    it('throws when apikey method has no apikey', async () => {
+      await expect(
+        apiClient.authenticate({
+          method: 'apikey',
+        } as AuthCredentials),
+      ).rejects.toThrow('API key is required for apikey authentication');
+    });
+  });
+});

--- a/src/services/connection/api-client.ts
+++ b/src/services/connection/api-client.ts
@@ -38,9 +38,13 @@ export class RevisiumApiClient {
   }
 
   private async authenticateWithApiKey(apikey: string): Promise<string> {
-    this.client.loginWithToken(apikey);
-    const me = await this.client.me();
-    return me.username || 'authenticated user';
+    this.client.loginWithApiKey(apikey);
+    try {
+      const me = await this.client.me();
+      return me.username || 'authenticated user';
+    } catch {
+      return 'service account';
+    }
   }
 
   private async authenticateWithPassword(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds explicit protocol override in Revisium URLs and API key auth via `X-Api-Key`. Predictable HTTP/HTTPS selection and support for both personal and service keys.

- **New Features**
  - URLs: Support `revisium+http://` and `revisium+https://`; parser and base URL builder honor overrides.
  - Auth: Use `loginWithApiKey` for `rev_` keys via `X-Api-Key`; return "service account" when `me()` fails; validate missing token/key; unit tests added; docs updated.

- **Dependencies**
  - Bumped `@revisium/client` to `0.5.0`.

<sup>Written for commit 034b2a7b325061ace2397d61904ced7e49014ff8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

