### PR TITLE
fix(docs): correct API key prefix from ak_ to rev_

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ All commands support configuration via environment variables.
 |----------|-------------|---------|
 | `REVISIUM_URL` | Revisium URL (see [URL Format](./url-format.md)) | `revisium://cloud.revisium.io/org/proj/main` |
 | `REVISIUM_TOKEN` | JWT authentication token | `eyJhbGciOiJIUzI1NiIs...` |
-| `REVISIUM_API_KEY` | API key (for automated access) | `ak_xxxxxxxxxxxxx` |
+| `REVISIUM_API_KEY` | API key (for automated access) | `rev_xxxxxxxxxxxxx` |
 | `REVISIUM_USERNAME` | Username (for password auth) | `admin` |
 | `REVISIUM_PASSWORD` | Password (for password auth) | `secret` |
 

--- a/docs/url-format.md
+++ b/docs/url-format.md
@@ -96,13 +96,13 @@ Get your token:
 API key in URL query parameter:
 
 ```bash
-revisium://cloud.revisium.io/myorg/myproject/master?apikey=ak_xxxxxxxxxxxxx
+revisium://cloud.revisium.io/myorg/myproject/master?apikey=rev_xxxxxxxxxxxxx
 ```
 
 API key via environment variable:
 
 ```bash
-export REVISIUM_API_KEY=ak_xxxxxxxxxxxxx
+export REVISIUM_API_KEY=rev_xxxxxxxxxxxxx
 revisium migrate apply --file ./migrations.json \
   --url revisium://cloud.revisium.io/myorg/myproject/master
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
-        "@revisium/client": "^0.5.0",
+        "@revisium/client": "^0.6.0",
         "@revisium/schema-toolkit": "^0.4.1",
         "@types/object-hash": "^3.0.6",
         "ajv": "^8.18.0",
@@ -3953,9 +3953,9 @@
       }
     },
     "node_modules/@revisium/client": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@revisium/client/-/client-0.5.0.tgz",
-      "integrity": "sha512-z3Yks0zwcgKlYENToyj197/gd+kQXeVF/NxwndtLjuJw1ECjr1/UrlFugf0IDYp8f5TWJp2Ur/983W+fEyDkUg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@revisium/client/-/client-0.6.0.tgz",
+      "integrity": "sha512-v9IbVGS/2wFQ5jtapUq90dShAOFIw2GDF1WNLH164/Ruz7pOtudaQpSxXnpirVGaMgdvF+FnUqfzXqUf3yPIBw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
-    "@revisium/client": "^0.5.0",
+    "@revisium/client": "^0.6.0",
     "@revisium/schema-toolkit": "^0.4.1",
     "@types/object-hash": "^3.0.6",
     "ajv": "^8.18.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the API key prefix in docs from ak_ to rev_ so examples match the current format, and bumped `@revisium/client` to `0.6.0`.

Updated `REVISIUM_API_KEY` and URL query examples in `docs/configuration.md` and `docs/url-format.md` to use the `rev_` prefix.

<sup>Written for commit 4f8821185c91fd1e11cf91b4a82212c31488b46a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

