### PR TITLE
feat: add workspace contexts for cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,22 @@ revisium sync all \
 | `sync schema` | Sync schema between projects | [Sync Commands](docs/sync-commands.md) |
 | `sync data` | Sync data between projects | [Sync Commands](docs/sync-commands.md) |
 | `sync all` | Full sync (schema + data) | [Sync Commands](docs/sync-commands.md) |
+| `instance add/list/show/remove` | Manage workspace Revisium instances | [Workspace Config](docs/workspace-config.md) |
+| `context create/list/show/use/remove` | Manage workspace Revisium contexts | [Workspace Config](docs/workspace-config.md) |
 
 ## Configuration
 
-Configure via environment variables or `.env` file:
+Configure via workspace config, environment variables, or `.env` file:
+
+```bash
+# Workspace-local standalone example without auth
+revisium instance add local --url revisium://localhost:9222 --auth none
+revisium context create dictionary-local \
+  --url revisium://localhost:9222/admin/dictionary/master
+revisium context use dictionary-local
+```
+
+Then single-target commands can omit `--url` in that workspace.
 
 ```env
 # Recommended: URL + Token
@@ -178,6 +190,7 @@ See [Configuration](docs/configuration.md) and [URL Format](docs/url-format.md) 
 ## Documentation
 
 - [Configuration](docs/configuration.md) - Environment variables and .env files
+- [Workspace Config](docs/workspace-config.md) - non-secret instances and contexts
 - [URL Format](docs/url-format.md) - Revisium URL syntax
 - [Authentication](docs/authentication.md) - Token, API key, and password auth
 - [Auth Contexts And Bootstrap Plan](docs/auth-contexts-and-bootstrap-plan.md) - proposed saved auth, contexts, and example bootstrap workflow

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Revisium CLI supports three authentication methods (mutually exclusive).
+Revisium CLI supports three authentication methods for authenticated instances. Workspace contexts can also opt into explicit no-auth mode for local standalone demos.
 
 ## Token Authentication (Recommended)
 
@@ -54,6 +54,19 @@ export REVISIUM_USERNAME=admin
 export REVISIUM_PASSWORD=secret
 ```
 
+## No Auth For Local Standalone
+
+Use workspace config when a standalone instance runs with auth disabled:
+
+```bash
+revisium instance add local --url revisium://localhost:9222 --auth none
+revisium context create dictionary-local \
+  --url revisium://localhost:9222/admin/dictionary/master
+revisium context use dictionary-local
+```
+
+`authMode: "none"` sends no auth headers and bypasses prompts. Do not use it for cloud or shared authenticated instances.
+
 ## Interactive Mode
 
 If no credentials are provided, you'll be prompted:
@@ -95,9 +108,10 @@ Paste token: ****
 
 ## Priority
 
-1. **URL auth** (`?token=...` or `user:pass@host`)
+1. **URL auth** (`?token=...`, `?apikey=...`, or `user:pass@host`)
 2. **Environment variables** (`TOKEN` > `API_KEY` > `USERNAME/PASSWORD`)
-3. **Interactive prompts**
+3. **Workspace no-auth mode** (`authMode: "none"`)
+4. **Interactive prompts**
 
 ## Validation
 
@@ -159,3 +173,4 @@ revisium sync all \
 
 - [URL Format](./url-format.md) - URL syntax
 - [Configuration](./configuration.md) - Environment variables
+- [Workspace Config](./workspace-config.md) - no-auth local contexts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,22 @@
 # Configuration
 
+## Workspace Config
+
+Single-target commands can use a workspace config at `.revisium/revisium-cli.config.json` when no `--url` and no `REVISIUM_URL` are provided.
+
+```bash
+revisium instance add local --url revisium://localhost:9222 --auth none
+revisium context create dictionary-local \
+  --url revisium://localhost:9222/admin/dictionary/master
+revisium context use dictionary-local
+
+revisium schema save --folder ./schemas
+```
+
+The workspace config stores only non-secret instance and context data. Keep tokens, API keys, and passwords in environment variables or explicit URL/auth inputs.
+
+See [Workspace Config](./workspace-config.md).
+
 ## Environment Variables
 
 All commands support configuration via environment variables.
@@ -31,12 +48,14 @@ All commands support configuration via environment variables.
 
 ### Authentication Priority
 
-When using `--url`, authentication is resolved in this order:
+For explicit URLs and environment targets, authentication is resolved in this order:
 
 1. **URL query parameter** - `?token=...` or `?apikey=...`
 2. **URL credentials** - `user:pass@host`
 3. **Environment variable** - `REVISIUM_TOKEN` > `REVISIUM_API_KEY` > `REVISIUM_USERNAME/PASSWORD`
 4. **Interactive prompt** - if running in terminal
+
+When a workspace context is used, URL and environment auth still win. If the selected instance has `authMode: "none"`, the CLI sends no auth. `authMode: "stored"` currently requires URL or environment credentials until saved credential commands are implemented.
 
 **Important:** You can use `--url` to specify host/org/project/branch and provide credentials via environment:
 
@@ -99,9 +118,10 @@ revisium schema save --folder ./schemas \
 
 Configuration is resolved in this order (highest to lowest):
 
-1. **Command-line options** (`--url`)
+1. **Command-line target options** (`--url`, `--context`)
 2. **Environment variables** (`REVISIUM_URL`, `REVISIUM_TOKEN`, etc.)
-3. **Interactive prompts** (for missing values)
+3. **Current workspace context** (`.revisium/revisium-cli.config.json`)
+4. **Interactive prompts** (for missing values)
 
 ## Examples
 
@@ -142,4 +162,5 @@ env:
 ## See Also
 
 - [Authentication](./authentication.md) - Token, API key, and password auth
+- [Workspace Config](./workspace-config.md) - workspace instances and contexts
 - [URL Format](./url-format.md) - Revisium URL syntax

--- a/docs/workspace-config.md
+++ b/docs/workspace-config.md
@@ -1,0 +1,124 @@
+# Workspace Config
+
+Workspace config lets local projects keep non-secret Revisium targets in git so repeated commands do not need `--url`.
+
+The CLI discovers the nearest config by walking up from the current directory:
+
+```text
+.revisium/revisium-cli.config.json
+```
+
+This file stores instance aliases, context aliases, and the active context. It must not store API keys, JWTs, passwords, or URLs with `?token=...` / `?apikey=...`.
+
+## Local Standalone
+
+For standalone started without auth, use an explicit no-auth instance:
+
+```bash
+revisium instance add local --url revisium://localhost:9222 --auth none
+revisium context create dictionary-local \
+  --url revisium://localhost:9222/admin/dictionary/master
+revisium context use dictionary-local
+```
+
+CLI input may use the Revisium URL scheme. The saved instance `baseUrl` is normalized to the transport URL,
+such as `http://localhost:9222` or `https://cloud.revisium.io`, when written to `.revisium/revisium-cli.config.json`.
+
+Then normal single-target commands can omit `--url`:
+
+```bash
+revisium schema save --folder ./schemas
+revisium migrate apply --file ./migrations.json
+revisium rows upload --folder ./data
+```
+
+When a command resolves its target from workspace config, it prints the selected context and instance:
+
+```text
+Using context dictionary-local (instance: local)
+```
+
+To inspect the current context without running a data command:
+
+```bash
+revisium context show
+```
+
+This is intended for examples and local demo projects. The committed config contains the server location and target metadata:
+organization, project, branch, and revision. It should not contain credentials.
+
+## Authenticated Instances
+
+For authenticated instances, keep secrets in environment variables for now. The workspace config should describe the target,
+while credentials come from the shell or CI secret store:
+
+```bash
+revisium instance add cloud --url revisium://cloud.revisium.io --auth stored
+revisium context create dictionary-cloud \
+  --url revisium://cloud.revisium.io/admin/dictionary/master
+revisium context use dictionary-cloud
+
+export REVISIUM_API_KEY=rev_xxxxxxxxxxxxxxxxxxxx
+revisium schema save --folder ./schemas
+```
+
+`authMode: "stored"` reserves the workspace shape for named stored credentials, but this implementation does not save API keys to an OS credential store yet. If no URL or environment credentials are available, stored mode fails with a remediation message. The optional context `credential` field is written only when `--credential` is passed.
+
+URL-embedded credentials such as `revisium://user:pass@host`, `?token=...`, and `?apikey=...` remain supported for compatibility
+and emergencies, but avoid them in normal usage because they can leak through shell history, process listings, and logs.
+
+## Commands
+
+```bash
+revisium instance add <name> --url <revisium-server-url> [--auth none|stored]
+revisium instance list
+revisium instance show <name>
+revisium instance remove <name>
+
+revisium context create <name> --url <revisium-url> [--instance <name>] [--credential <name>]
+revisium context create <name> --instance <name> --org <org> --project <project> [--branch <branch>] [--revision <revision>]
+revisium context list
+revisium context show [name]
+revisium context use <name>
+revisium context remove <name>
+```
+
+`context create --url` uses an existing instance with the same server base URL. If no matching instance exists, add it first with `revisium instance add`.
+
+## Config Shape
+
+```json
+{
+  "version": 1,
+  "currentContext": "dictionary-local",
+  "instances": {
+    "local": {
+      "baseUrl": "http://localhost:9222",
+      "authMode": "none"
+    }
+  },
+  "contexts": {
+    "dictionary-local": {
+      "instance": "local",
+      "organization": "admin",
+      "project": "dictionary",
+      "branch": "master",
+      "revision": "draft"
+    }
+  }
+}
+```
+
+## Precedence
+
+For single-target commands, command target options win first: `--url` selects an explicit URL, and `--context` selects a workspace context. `REVISIUM_URL` is used only when no command target option is provided. The current workspace context is used only when no command target option and no `REVISIUM_URL` are provided.
+
+Authentication remains explicit:
+
+1. Environment auth: `REVISIUM_TOKEN` > `REVISIUM_API_KEY` > `REVISIUM_USERNAME` / `REVISIUM_PASSWORD`
+2. URL auth, discouraged except for compatibility or emergencies: `?token=...`, `?apikey=...`, or `user:password@host`
+3. Workspace `authMode: "none"`
+4. Stored credentials in a future implementation
+5. Interactive prompt for non-workspace URL flows
+
+Sync commands still use `--source`, `--target`, and the `REVISIUM_SOURCE_*` / `REVISIUM_TARGET_*` environment variables.

--- a/e2e/tests/07-workspace-config.e2e-spec.ts
+++ b/e2e/tests/07-workspace-config.e2e-spec.ts
@@ -1,0 +1,490 @@
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import * as fs from 'fs';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import { runCli, buildUrl } from '../utils/cli-runner';
+import { waitForHealthy } from '../utils/docker-helper';
+import { createTestProject, generateProjectName } from '../utils/test-project';
+import { FIXTURES_PATH } from '../utils/constants';
+
+const REPO_ROOT = process.cwd();
+const MIGRATIONS_FILE = path.join(REPO_ROOT, FIXTURES_PATH, 'migrations.json');
+const CLEAR_REVISIUM_ENV = {
+  REVISIUM_URL: '',
+  REVISIUM_TOKEN: '',
+  REVISIUM_API_KEY: '',
+  REVISIUM_USERNAME: '',
+  REVISIUM_PASSWORD: '',
+};
+
+interface WorkspaceConfig {
+  version: number;
+  currentContext?: string;
+  instances: Record<string, { baseUrl: string; authMode?: string }>;
+  contexts: Record<
+    string,
+    {
+      instance: string;
+      credential?: string;
+      organization: string;
+      project: string;
+      branch?: string;
+      revision?: string;
+    }
+  >;
+}
+
+interface StandaloneHandle {
+  child: ChildProcessWithoutNullStreams;
+  dataDir: string;
+  port: number;
+  output: () => string;
+}
+
+describe('Workspace config commands', () => {
+  let workspaces: string[] = [];
+  let standaloneHandles: StandaloneHandle[] = [];
+
+  afterEach(async () => {
+    for (const handle of standaloneHandles) {
+      await stopStandalone(handle);
+    }
+    standaloneHandles = [];
+
+    for (const workspace of workspaces) {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+    workspaces = [];
+  });
+
+  it('manages instances and contexts in a single workspace config', async () => {
+    const workspace = createWorkspace();
+    const firstProject = await createTestProject();
+    const secondProject = await createTestProject();
+
+    const emptyInstances = await runCli(['instance', 'list'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+
+    expect(emptyInstances.exitCode).toBe(0);
+    expect(emptyInstances.stdout).toContain('No Revisium instances configured');
+
+    const addStored = await runCli(
+      ['instance', 'add', 'local', '--url', 'revisium://localhost:8082'],
+      { cwd: workspace, env: CLEAR_REVISIUM_ENV },
+    );
+    const addNoAuth = await runCli(
+      [
+        'instance',
+        'add',
+        'local-no-auth',
+        '--url',
+        'revisium://localhost:8082',
+        '--auth',
+        'none',
+      ],
+      { cwd: workspace, env: CLEAR_REVISIUM_ENV },
+    );
+
+    expect(addStored.exitCode).toBe(0);
+    expect(addStored.stdout).toContain('Added instance "local"');
+    expect(addNoAuth.exitCode).toBe(0);
+    expect(addNoAuth.stdout).toContain('auth: none');
+
+    const showInstance = await runCli(['instance', 'show', 'local-no-auth'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+
+    expect(showInstance.exitCode).toBe(0);
+    expect(showInstance.stdout).toContain('Auth mode: none');
+
+    const createFromUrl = await runCli(
+      [
+        'context',
+        'create',
+        'first',
+        '--url',
+        buildUrl(firstProject.name),
+        '--instance',
+        'local',
+      ],
+      { cwd: workspace, env: CLEAR_REVISIUM_ENV },
+    );
+    const createFromParts = await runCli(
+      [
+        'context',
+        'create',
+        'second',
+        '--instance',
+        'local',
+        '--org',
+        'admin',
+        '--project',
+        secondProject.name,
+        '--revision',
+        'head',
+      ],
+      { cwd: workspace, env: CLEAR_REVISIUM_ENV },
+    );
+
+    expect(createFromUrl.exitCode).toBe(0);
+    expect(createFromUrl.stdout).toContain('Created context "first"');
+    expect(createFromParts.exitCode).toBe(0);
+    expect(createFromParts.stdout).toContain('admin/');
+    expect(createFromParts.stdout).toContain(':head');
+
+    const listContexts = await runCli(['context', 'list'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+
+    expect(listContexts.exitCode).toBe(0);
+    expect(listContexts.stdout).toContain('* first');
+    expect(listContexts.stdout).toContain('second');
+
+    const useSecond = await runCli(['context', 'use', 'second'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+    const showCurrent = await runCli(['context', 'show'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+
+    expect(useSecond.exitCode).toBe(0);
+    expect(showCurrent.exitCode).toBe(0);
+    expect(showCurrent.stdout).toContain('Name: second');
+    expect(showCurrent.stdout).toContain(`Target: admin/${secondProject.name}`);
+    expect(showCurrent.stdout).toContain('Credential: default');
+    expect(readWorkspaceConfig(workspace).contexts.second.credential).toBe(
+      undefined,
+    );
+
+    const blockedRemove = await runCli(['instance', 'remove', 'local'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+
+    expect(blockedRemove.exitCode).toBe(1);
+    expect(blockedRemove.stdout + blockedRemove.stderr).toContain(
+      'used by contexts',
+    );
+
+    await expectSuccess(
+      runCli(['context', 'remove', 'first'], {
+        cwd: workspace,
+        env: CLEAR_REVISIUM_ENV,
+      }),
+    );
+    await expectSuccess(
+      runCli(['context', 'remove', 'second'], {
+        cwd: workspace,
+        env: CLEAR_REVISIUM_ENV,
+      }),
+    );
+    await expectSuccess(
+      runCli(['instance', 'remove', 'local'], {
+        cwd: workspace,
+        env: CLEAR_REVISIUM_ENV,
+      }),
+    );
+    await expectSuccess(
+      runCli(['instance', 'remove', 'local-no-auth'], {
+        cwd: workspace,
+        env: CLEAR_REVISIUM_ENV,
+      }),
+    );
+
+    const config = readWorkspaceConfig(workspace);
+    expect(config.instances).toEqual({});
+    expect(config.contexts).toEqual({});
+    expect(config.currentContext).toBeUndefined();
+  });
+
+  it('uses current workspace context when --url is omitted', async () => {
+    const workspace = createWorkspace();
+    const project = await createTestProject();
+    const token = process.env.E2E_ADMIN_TOKEN!;
+
+    await applyMigrations(project.name, token);
+    await createStoredWorkspaceContext(workspace, 'current', project.name);
+
+    const outputDir = path.join(workspace, 'schemas');
+    const result = await runCli(['schema', 'save', '--folder', outputDir], {
+      cwd: workspace,
+      env: {
+        ...CLEAR_REVISIUM_ENV,
+        REVISIUM_TOKEN: token,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Using context current (instance: local)');
+    expect(result.stdout).toContain('Authenticated as admin');
+    expect(fs.readdirSync(outputDir)).toHaveLength(14);
+  });
+
+  it('uses --context to override the current workspace context', async () => {
+    const workspace = createWorkspace();
+    const emptyProject = await createTestProject();
+    const populatedProject = await createTestProject();
+    const token = process.env.E2E_ADMIN_TOKEN!;
+
+    await applyMigrations(populatedProject.name, token);
+    await createStoredWorkspaceContext(workspace, 'empty', emptyProject.name);
+    await createStoredWorkspaceContext(
+      workspace,
+      'populated',
+      populatedProject.name,
+    );
+
+    const outputDir = path.join(workspace, 'schemas-from-populated');
+    const result = await runCli(
+      ['schema', 'save', '--context', 'populated', '--folder', outputDir],
+      {
+        cwd: workspace,
+        env: {
+          ...CLEAR_REVISIUM_ENV,
+          REVISIUM_URL: buildUrl(emptyProject.name),
+          REVISIUM_TOKEN: token,
+        },
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(
+      'Using context populated (instance: local)',
+    );
+    expect(result.stdout).toContain(`Project: admin/${populatedProject.name}`);
+    expect(fs.readdirSync(outputDir)).toHaveLength(14);
+  });
+
+  it('fails clearly when a stored context has no credentials', async () => {
+    const workspace = createWorkspace();
+    const project = await createTestProject();
+
+    await createStoredWorkspaceContext(workspace, 'needs-auth', project.name);
+
+    const result = await runCli(
+      ['schema', 'save', '--folder', path.join(workspace, 'schemas')],
+      {
+        cwd: workspace,
+        env: CLEAR_REVISIUM_ENV,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain('No credentials found');
+    expect(result.stdout + result.stderr).toContain('REVISIUM_API_KEY');
+    expect(result.stdout + result.stderr).toContain('authMode "none"');
+  });
+
+  it('uses authMode none against a no-auth standalone instance', async () => {
+    const workspace = createWorkspace();
+    const standalone = await startNoAuthStandalone();
+    standaloneHandles.push(standalone);
+
+    const projectName = generateProjectName('e2e-noauth');
+    const baseUrl = `revisium://localhost:${standalone.port}`;
+    const targetUrl = `${baseUrl}/admin/${projectName}/master`;
+
+    await expectSuccess(
+      runCli(
+        [
+          'instance',
+          'add',
+          'local-no-auth',
+          '--url',
+          baseUrl,
+          '--auth',
+          'none',
+        ],
+        { cwd: workspace, env: CLEAR_REVISIUM_ENV },
+      ),
+    );
+    await expectSuccess(
+      runCli(['context', 'create', 'demo', '--url', targetUrl], {
+        cwd: workspace,
+        env: CLEAR_REVISIUM_ENV,
+      }),
+    );
+
+    const migrateResult = await runCli(
+      ['migrate', 'apply', '--file', MIGRATIONS_FILE, '--create-project'],
+      {
+        cwd: workspace,
+        env: CLEAR_REVISIUM_ENV,
+        timeout: 90000,
+      },
+    );
+
+    expect(migrateResult.exitCode).toBe(0);
+    expect(migrateResult.stdout).toContain(
+      'Using context demo (instance: local-no-auth)',
+    );
+    expect(migrateResult.stdout).toContain('Authenticated as no auth');
+
+    const outputDir = path.join(workspace, 'schemas-no-auth');
+    const saveResult = await runCli(['schema', 'save', '--folder', outputDir], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+
+    expect(saveResult.exitCode).toBe(0);
+    expect(saveResult.stdout).toContain(
+      'Using context demo (instance: local-no-auth)',
+    );
+    expect(saveResult.stdout).toContain('Authenticated as no auth');
+    expect(fs.readdirSync(outputDir)).toHaveLength(14);
+  }, 120000);
+
+  function createWorkspace(): string {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-workspace-'));
+    workspaces.push(workspace);
+    return workspace;
+  }
+});
+
+async function createStoredWorkspaceContext(
+  workspace: string,
+  contextName: string,
+  projectName: string,
+): Promise<void> {
+  await expectSuccess(
+    runCli(['instance', 'add', 'local', '--url', 'revisium://localhost:8082'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    }),
+  );
+  await expectSuccess(
+    runCli(['context', 'create', contextName, '--url', buildUrl(projectName)], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    }),
+  );
+}
+
+async function applyMigrations(
+  projectName: string,
+  token: string,
+): Promise<void> {
+  await expectSuccess(
+    runCli([
+      'migrate',
+      'apply',
+      '--url',
+      buildUrl(projectName, { token }),
+      '--file',
+      MIGRATIONS_FILE,
+    ]),
+  );
+}
+
+async function expectSuccess(resultPromise: Promise<{ exitCode: number }>) {
+  const result = await resultPromise;
+  expect(result.exitCode).toBe(0);
+}
+
+function readWorkspaceConfig(workspace: string): WorkspaceConfig {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(workspace, '.revisium', 'revisium-cli.config.json'),
+      'utf-8',
+    ),
+  ) as WorkspaceConfig;
+}
+
+async function startNoAuthStandalone(): Promise<StandaloneHandle> {
+  const port = await getFreePort();
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-noauth-data-'));
+  const binPath = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '@revisium',
+    'standalone',
+    'bin',
+    'revisium-standalone.js',
+  );
+  let output = '';
+
+  const child = spawn(
+    process.execPath,
+    [binPath, '--port', String(port), '--data', dataDir],
+    {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        FILE_PLUGIN_PUBLIC_ENDPOINT: 'https://cdn.example.com',
+      },
+    },
+  );
+
+  child.stdout.on('data', (data: Buffer) => {
+    output += data.toString();
+  });
+  child.stderr.on('data', (data: Buffer) => {
+    output += data.toString();
+  });
+
+  let ready = false;
+  const exitedEarly = new Promise<never>((_, reject) => {
+    child.once('exit', (code, signal) => {
+      if (!ready) {
+        reject(
+          new Error(
+            `No-auth standalone exited before readiness (${code ?? signal}).\n${output}`,
+          ),
+        );
+      }
+    });
+  });
+
+  try {
+    await Promise.race([
+      waitForHealthy(`http://localhost:${port}/health/readiness`, 90000),
+      exitedEarly,
+    ]);
+    ready = true;
+  } catch (error) {
+    await stopStandalone({ child, dataDir, port, output: () => output });
+    throw error;
+  }
+
+  return {
+    child,
+    dataDir,
+    port,
+    output: () => output,
+  };
+}
+
+async function stopStandalone(handle: StandaloneHandle): Promise<void> {
+  if (handle.child.exitCode === null && !handle.child.killed) {
+    handle.child.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      handle.child.once('close', () => resolve());
+    });
+  }
+
+  fs.rmSync(handle.dataDir, { recursive: true, force: true });
+}
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Could not allocate a free TCP port'));
+        return;
+      }
+
+      server.close(() => resolve(address.port));
+    });
+  });
+}

--- a/e2e/utils/cli-runner.ts
+++ b/e2e/utils/cli-runner.ts
@@ -21,11 +21,13 @@ export async function runCli(
   const { env = {}, timeout = 60000, cwd = process.cwd() } = options;
 
   const isInstrumented = process.env.E2E_INSTRUMENTED === '1';
-  const mainPath = isInstrumented
-    ? 'dist-instrumented/src/main.js'
-    : 'dist/src/main.js';
+  const projectRoot = process.cwd();
+  const mainPath = path.join(
+    projectRoot,
+    isInstrumented ? 'dist-instrumented/src/main.js' : 'dist/src/main.js',
+  );
 
-  const nycOutputDir = path.join(cwd, '.nyc_output');
+  const nycOutputDir = path.join(projectRoot, '.nyc_output');
   if (isInstrumented && !fs.existsSync(nycOutputDir)) {
     fs.mkdirSync(nycOutputDir, { recursive: true });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
-        "@revisium/standalone": "2.6.0",
+        "@revisium/standalone": "2.8.1",
         "@swc/cli": "^0.6.0",
         "@swc/core": "^1.10.7",
         "@types/express": "^5.0.0",
@@ -717,43 +717,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -790,33 +753,33 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
-      "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
+      "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
-      "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
+      "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
       },
       "peerDependencies": {
-        "@electric-sql/pglite": "0.3.15"
+        "@electric-sql/pglite": "0.4.1"
       }
     },
     "node_modules/@electric-sql/pglite-tools": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
-      "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
+      "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@electric-sql/pglite": "0.3.15"
+        "@electric-sql/pglite": "0.4.1"
       }
     },
     "node_modules/@embedded-postgres/darwin-arm64": {
@@ -1166,9 +1129,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3015,6 +2978,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -3022,20 +2992,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@mrleebo/prisma-ast": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
-      "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chevrotain": "^10.5.0",
-        "lilconfig": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@napi-rs/nice": {
@@ -3532,9 +3488,9 @@
       }
     },
     "node_modules/@nestjs/microservices": {
-      "version": "11.1.13",
-      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.13.tgz",
-      "integrity": "sha512-o7KNZlJJe+6Qo/GdUeofIgrUINzSVYkl3UZ5px+e+fHhftDfx+W41QuKu+EXPkOm02R6qApDFp3UeIyJrBdS9g==",
+      "version": "11.1.19",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.19.tgz",
+      "integrity": "sha512-3Oja56ydTlSaui19/i7gYM0MMqz/w4UR2aqZeL4K8B+Fq0Ztg3zHb8et76atToJGpSCevJLEsoEMOMaGgzRwfg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3814,42 +3770,42 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.5.0.tgz",
-      "integrity": "sha512-1J/9YEX7A889xM46PYg9e8VAuSL1IUmXJW3tEhMv7XQHDWlfC9YSkIw9sTYRaq5GswGlxZ+GnnyiNsUZ9JJhSQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
+      "integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "c12": "3.1.0",
+        "c12": "3.3.4",
         "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
+        "effect": "3.20.0",
         "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
-      "integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.8.0.tgz",
+      "integrity": "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
-      "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
+      "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@electric-sql/pglite": "0.3.15",
-        "@electric-sql/pglite-socket": "0.0.20",
-        "@electric-sql/pglite-tools": "0.2.20",
-        "@hono/node-server": "1.19.9",
-        "@mrleebo/prisma-ast": "0.13.1",
+        "@electric-sql/pglite": "0.4.1",
+        "@electric-sql/pglite-socket": "0.1.1",
+        "@electric-sql/pglite-tools": "0.3.1",
+        "@hono/node-server": "1.19.11",
         "@prisma/get-platform": "7.2.0",
         "@prisma/query-plan-executor": "7.2.0",
+        "@prisma/streams-local": "0.1.2",
         "foreground-child": "3.3.1",
         "get-port-please": "3.2.0",
-        "hono": "4.11.4",
+        "hono": "^4.12.8",
         "http-status-codes": "2.3.0",
         "pathe": "2.0.3",
         "proper-lockfile": "4.1.2",
@@ -3860,56 +3816,56 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.5.0.tgz",
-      "integrity": "sha512-ondGRhzoaVpRWvFaQ5wH5zS1BIbhzbKqczKjCn6j3L0Zfe/LInjcEg8+xtB49AuZBX30qyx1ZtGoootUohz2pw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
+      "integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.5.0",
-        "@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-        "@prisma/fetch-engine": "7.5.0",
-        "@prisma/get-platform": "7.5.0"
+        "@prisma/debug": "7.8.0",
+        "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+        "@prisma/fetch-engine": "7.8.0",
+        "@prisma/get-platform": "7.8.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e.tgz",
-      "integrity": "sha512-E+iRV/vbJLl8iGjVr6g/TEWokA+gjkV/doZkaQN1i/ULVdDwGnPJDfLUIFGS3BVwlG/m6L8T4x1x5isl8hGMxA==",
+      "version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
+      "integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
-      "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
+      "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.5.0"
+        "@prisma/debug": "7.8.0"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.5.0.tgz",
-      "integrity": "sha512-kZCl2FV54qnyrVdnII8MI6qvt7HfU6Cbiz8dZ8PXz4f4lbSw45jEB9/gEMK2SGdiNhBKyk/Wv95uthoLhGMLYA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
+      "integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.5.0",
-        "@prisma/engines-version": "7.5.0-15.280c870be64f457428992c43c1f6d557fab6e29e",
-        "@prisma/get-platform": "7.5.0"
+        "@prisma/debug": "7.8.0",
+        "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+        "@prisma/get-platform": "7.8.0"
       }
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.5.0.tgz",
-      "integrity": "sha512-7I+2y1nu/gkEKSiHHbcZ1HPe/euGdEqJZxEEMT0246q4De1+hla0ZzlTgvaT9dHcVCgLSuCG8v39db5qUUWNgw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
+      "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.5.0"
+        "@prisma/debug": "7.8.0"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -3936,20 +3892,188 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@prisma/studio-core": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.21.1.tgz",
-      "integrity": "sha512-bOGqG/eMQtKC0XVvcVLRmhWWzm/I+0QUWqAEhEBtetpuS3k3V4IWqKGUONkAIT223DNXJMxMtZp36b1FmcdPeg==",
+    "node_modules/@prisma/streams-local": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
+      "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "better-result": "^2.7.0",
+        "env-paths": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
+      },
       "engines": {
-        "node": "^20.19 || ^22.12 || ^24.0",
+        "bun": ">=1.3.6",
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@prisma/studio-core": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
+      "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@radix-ui/react-toggle": "1.1.10",
+        "chart.js": "4.5.1"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0",
         "pnpm": "8"
       },
       "peerDependencies": {
         "@types/react": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@revisium/client": {
@@ -3992,17 +4116,18 @@
       }
     },
     "node_modules/@revisium/standalone": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@revisium/standalone/-/standalone-2.6.0.tgz",
-      "integrity": "sha512-hl6A7Ehoqst/V4l7Z+d0mVm2SY2ONYyaiB5DIXDhvM5resrFwwh3Bdjpm2ryQhpw5C/4FtVf3j4MquQnS0VLdg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@revisium/standalone/-/standalone-2.8.1.tgz",
+      "integrity": "sha512-CP2D5Qz5fDc/Z/GlANqHwHzz7dNHu0sfIDniK3AQETjLkZp1kp0y78tIV9LKFSAQqPoBRwviGQwA/hPFR9sMSA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@nestjs/microservices": "^11.1.11",
+        "@nestjs/microservices": "^11.1.19",
         "bcrypt": "^6.0.0",
         "embedded-postgres": "18.1.0-beta.16",
-        "prisma": "^7.2.0",
-        "sharp": "^0.34.5"
+        "prisma": "^7.6.0",
+        "sharp": "^0.34.5",
+        "swagger-ui-dist": "^5.31.0"
       },
       "bin": {
         "revisium-standalone": "bin/revisium-standalone.js"
@@ -4010,6 +4135,14 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -5863,6 +5996,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/better-result": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.2.tgz",
+      "integrity": "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bin-version": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz",
@@ -6088,32 +6228,75 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
-      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.3",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^16.6.1",
-        "exsolve": "^1.0.7",
-        "giget": "^2.0.0",
-        "jiti": "^2.4.2",
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^2.2.0",
-        "rc9": "^2.1.2"
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
-        "magicast": "^0.3.5"
+        "magicast": "*"
       },
       "peerDependenciesMeta": {
         "magicast": {
           "optional": true
         }
+      }
+    },
+    "node_modules/c12/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/c12/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -6308,19 +6491,17 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
     },
-    "node_modules/chevrotain": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "dev": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "10.5.0",
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "@chevrotain/utils": "10.5.0",
-        "lodash": "4.17.21",
-        "regexp-to-ast": "0.5.0"
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -6363,16 +6544,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -6929,9 +7100,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7070,9 +7241,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
+      "integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7177,6 +7348,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -8459,19 +8643,11 @@
       }
     },
     "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
+      "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
-      },
       "bin": {
         "giget": "dist/cli.mjs"
       }
@@ -8709,9 +8885,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9941,9 +10117,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
-      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10102,16 +10278,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/lines-and-columns": {
@@ -10692,13 +10858,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -11022,31 +11181,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "citty": "^0.2.0",
-        "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -11400,9 +11534,9 @@
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -11612,14 +11746,14 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -11757,17 +11891,17 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.5.0.tgz",
-      "integrity": "sha512-n30qZpWehaYQzigLjmuPisyEsvOzHt7bZeRyg8gZ5DvJo9FGjD+gNaY59Ns3hlLD5/jZH5GBeftIss0jDbUoLg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
+      "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "7.5.0",
-        "@prisma/dev": "0.20.0",
-        "@prisma/engines": "7.5.0",
-        "@prisma/studio-core": "0.21.1",
+        "@prisma/config": "7.8.0",
+        "@prisma/dev": "0.24.3",
+        "@prisma/engines": "7.8.0",
+        "@prisma/studio-core": "0.27.3",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
       },
@@ -11950,20 +12084,20 @@
       }
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11972,9 +12106,9 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11982,7 +12116,7 @@
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -12052,13 +12186,6 @@
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
-    },
-    "node_modules/regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/release-zalgo": {
       "version": "1.0.0",
@@ -13159,6 +13286,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.5.tgz",
+      "integrity": "sha512-7/FQfWe9A4qoyYFdAwy0chD0uDYidDp/ZT9VQ9LZlgD4AnnHJk8/+ytAA1HkJYOPySmK6helPDdJQMlcumt7HA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -13392,16 +13529,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
-    "@revisium/standalone": "2.6.0",
+    "@revisium/standalone": "2.8.1",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
     "@types/express": "^5.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,18 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ApplyMigrationsCommand } from 'src/commands/migration/apply-migrations.command';
+import { ContextCommand } from 'src/commands/context/context.command';
+import { ContextCreateCommand } from 'src/commands/context/context-create.command';
+import { ContextListCommand } from 'src/commands/context/context-list.command';
+import { ContextRemoveCommand } from 'src/commands/context/context-remove.command';
+import { ContextShowCommand } from 'src/commands/context/context-show.command';
+import { ContextUseCommand } from 'src/commands/context/context-use.command';
 import { CreateMigrationsCommand } from 'src/commands/schema/create-migrations.command';
+import { InstanceAddCommand } from 'src/commands/instance/instance-add.command';
+import { InstanceCommand } from 'src/commands/instance/instance.command';
+import { InstanceListCommand } from 'src/commands/instance/instance-list.command';
+import { InstanceRemoveCommand } from 'src/commands/instance/instance-remove.command';
+import { InstanceShowCommand } from 'src/commands/instance/instance-show.command';
 import { MigrationCommand } from 'src/commands/migration/migration.command';
 import { RowsCommand } from 'src/commands/rows/rows.command';
 import { SaveMigrationsCommand } from 'src/commands/migration/save-migrations.command';
@@ -40,6 +51,7 @@ import {
   getEnvFilePath,
   shouldIgnoreEnvFile,
 } from 'src/utils/env-config.utils';
+import { WorkspaceConfigService } from 'src/services/workspace';
 
 @Module({
   imports: [
@@ -53,6 +65,17 @@ import {
     MigrationCommand,
     ApplyMigrationsCommand,
     SaveMigrationsCommand,
+    InstanceCommand,
+    InstanceAddCommand,
+    InstanceListCommand,
+    InstanceShowCommand,
+    InstanceRemoveCommand,
+    ContextCommand,
+    ContextCreateCommand,
+    ContextListCommand,
+    ContextShowCommand,
+    ContextUseCommand,
+    ContextRemoveCommand,
     SchemaCommand,
     SaveSchemaCommand,
     CreateMigrationsCommand,
@@ -78,6 +101,7 @@ import {
     UrlBuilderService,
     UrlParserService,
     AuthPromptService,
+    WorkspaceConfigService,
   ],
 })
 export class AppModule {}

--- a/src/commands/base-sync.command.ts
+++ b/src/commands/base-sync.command.ts
@@ -1,6 +1,5 @@
-import { Option } from 'nest-commander';
+import { CommandRunner, Option } from 'nest-commander';
 import { ConfigService } from '@nestjs/config';
-import { BaseCommand } from 'src/commands/base.command';
 import { SyncApiService, CommitRevisionService } from 'src/services/sync';
 import {
   RevisiumUrlComplete,
@@ -21,7 +20,7 @@ export interface DataSyncOptions extends BaseSyncOptions {
   batchSize?: number;
 }
 
-export abstract class BaseSyncCommand extends BaseCommand {
+export abstract class BaseSyncCommand extends CommandRunner {
   constructor(
     protected readonly configService: ConfigService,
     protected readonly urlBuilder: UrlBuilderService,

--- a/src/commands/base.command.ts
+++ b/src/commands/base.command.ts
@@ -2,6 +2,7 @@ import { CommandRunner, Option } from 'nest-commander';
 
 export type BaseOptions = {
   url?: string;
+  context?: string;
 };
 
 export abstract class BaseCommand extends CommandRunner {
@@ -12,6 +13,16 @@ export abstract class BaseCommand extends CommandRunner {
     required: false,
   })
   public parseUrl(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--context <name>',
+    description:
+      'Named workspace context from .revisium/revisium-cli.config.json (single-target commands)',
+    required: false,
+  })
+  public parseContext(value: string) {
     return value;
   }
 }

--- a/src/commands/context/context-create.command.ts
+++ b/src/commands/context/context-create.command.ts
@@ -1,0 +1,173 @@
+import { CommandRunner, Option, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import {
+  DEFAULT_BRANCH,
+  DEFAULT_REVISION,
+  WorkspaceConfigService,
+  WorkspaceConfig,
+  WorkspaceContextConfig,
+} from 'src/services/workspace';
+
+interface Options {
+  url?: string;
+  instance?: string;
+  credential?: string;
+  org?: string;
+  project?: string;
+  branch?: string;
+  revision?: string;
+}
+
+@SubCommand({
+  name: 'create',
+  arguments: '<name>',
+  description: 'Create or update a workspace Revisium context',
+})
+export class ContextCreateCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(inputs: string[], options: Options): Promise<void> {
+    const name = inputs[0];
+    if (!name) {
+      throw new Error('Error: context name is required');
+    }
+
+    const loaded = await this.workspaceConfig.loadOrCreate();
+    const context = this.buildContext(loaded.config, options);
+    const existed = Boolean(loaded.config.contexts[name]);
+
+    loaded.config.contexts[name] = context;
+    if (!loaded.config.currentContext) {
+      loaded.config.currentContext = name;
+    }
+
+    await this.workspaceConfig.save(loaded.path, loaded.config);
+
+    this.logger.success(
+      `${existed ? 'Updated' : 'Created'} context "${name}" (${context.organization}/${context.project}/${context.branch || DEFAULT_BRANCH}:${context.revision || DEFAULT_REVISION})`,
+    );
+    this.logger.info(`Instance: ${context.instance}`);
+    this.logger.info(`Config: ${loaded.path}`);
+  }
+
+  private buildContext(
+    config: WorkspaceConfig,
+    options: Options,
+  ): WorkspaceContextConfig {
+    if (options.url) {
+      const parsed = this.workspaceConfig.parseContextUrl(options.url);
+      const instanceName =
+        options.instance ||
+        this.workspaceConfig.findInstanceNameByBaseUrl(config, parsed.baseUrl);
+
+      if (!instanceName || !config.instances[instanceName]) {
+        throw new Error(
+          `No instance found for ${parsed.baseUrl}. Run: revisium instance add <name> --url ${options.url}`,
+        );
+      }
+
+      return this.withCredential(
+        {
+          instance: instanceName,
+          organization: parsed.organization,
+          project: parsed.project,
+          branch: parsed.branch,
+          revision: parsed.revision,
+        },
+        options.credential,
+      );
+    }
+
+    if (!options.instance || !options.org || !options.project) {
+      throw new Error(
+        'Error: provide --url, or provide --instance, --org, and --project',
+      );
+    }
+
+    if (!config.instances[options.instance]) {
+      throw new Error(`Revisium instance "${options.instance}" was not found`);
+    }
+
+    return this.withCredential(
+      {
+        instance: options.instance,
+        organization: options.org,
+        project: options.project,
+        branch: options.branch || DEFAULT_BRANCH,
+        revision: options.revision || DEFAULT_REVISION,
+      },
+      options.credential,
+    );
+  }
+
+  private withCredential(
+    context: WorkspaceContextConfig,
+    credential: string | undefined,
+  ): WorkspaceContextConfig {
+    if (credential) {
+      return { ...context, credential };
+    }
+    return context;
+  }
+
+  @Option({
+    flags: '--url <url>',
+    description: 'Revisium target URL: revisium://host/org/project/branch',
+  })
+  parseUrl(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--instance <name>',
+    description: 'Instance name from workspace config',
+  })
+  parseInstance(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--credential <name>',
+    description: 'Named saved credential selector for stored auth',
+  })
+  parseCredential(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--org <organization>',
+    description: 'Organization id',
+  })
+  parseOrg(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--project <project>',
+    description: 'Project name',
+  })
+  parseProject(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--branch <branch>',
+    description: 'Branch name (default: master)',
+  })
+  parseBranch(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--revision <revision>',
+    description: 'Revision target (default: draft)',
+  })
+  parseRevision(value: string) {
+    return value;
+  }
+}

--- a/src/commands/context/context-list.command.ts
+++ b/src/commands/context/context-list.command.ts
@@ -1,0 +1,36 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import {
+  DEFAULT_BRANCH,
+  DEFAULT_REVISION,
+  WorkspaceConfigService,
+} from 'src/services/workspace';
+
+@SubCommand({
+  name: 'list',
+  description: 'List workspace Revisium contexts',
+})
+export class ContextListCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(): Promise<void> {
+    const loaded = await this.workspaceConfig.load();
+    if (!loaded || Object.keys(loaded.config.contexts).length === 0) {
+      this.logger.info('No Revisium contexts configured in this workspace.');
+      return;
+    }
+
+    this.logger.info(`Config: ${loaded.path}`);
+    for (const [name, context] of Object.entries(loaded.config.contexts)) {
+      const marker = loaded.config.currentContext === name ? '*' : ' ';
+      this.logger.info(
+        `${marker} ${name}\t${context.instance}\t${context.organization}/${context.project}/${context.branch || DEFAULT_BRANCH}:${context.revision || DEFAULT_REVISION}`,
+      );
+    }
+  }
+}

--- a/src/commands/context/context-remove.command.ts
+++ b/src/commands/context/context-remove.command.ts
@@ -1,0 +1,35 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+@SubCommand({
+  name: 'remove',
+  arguments: '<name>',
+  description: 'Remove a workspace Revisium context',
+})
+export class ContextRemoveCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(inputs: string[]): Promise<void> {
+    const name = inputs[0];
+    if (!name) {
+      throw new Error('Error: context name is required');
+    }
+
+    const { loaded } = await this.workspaceConfig.loadContext(name);
+
+    delete loaded.config.contexts[name];
+    if (loaded.config.currentContext === name) {
+      delete loaded.config.currentContext;
+    }
+
+    await this.workspaceConfig.save(loaded.path, loaded.config);
+
+    this.logger.success(`Removed context "${name}"`);
+  }
+}

--- a/src/commands/context/context-show.command.ts
+++ b/src/commands/context/context-show.command.ts
@@ -1,0 +1,59 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import {
+  DEFAULT_BRANCH,
+  DEFAULT_CREDENTIAL,
+  DEFAULT_REVISION,
+  WorkspaceConfigService,
+} from 'src/services/workspace';
+
+@SubCommand({
+  name: 'show',
+  arguments: '[name]',
+  description: 'Show a workspace Revisium context',
+})
+export class ContextShowCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(inputs: string[]): Promise<void> {
+    const loaded = await this.workspaceConfig.load();
+    if (!loaded) {
+      throw new Error('No Revisium workspace config found');
+    }
+
+    const name = inputs[0] || loaded.config.currentContext;
+    if (!name) {
+      throw new Error('No current Revisium context is configured');
+    }
+
+    const context = loaded.config.contexts[name];
+    if (!context) {
+      throw new Error(`Revisium context "${name}" was not found`);
+    }
+
+    const instance = loaded.config.instances[context.instance];
+
+    this.logger.info(`Name: ${name}`);
+    this.logger.info(`Instance: ${context.instance}`);
+    if (instance) {
+      this.logger.info(`Base URL: ${instance.baseUrl}`);
+      this.logger.info(`Auth mode: ${instance.authMode || 'stored'}`);
+    } else {
+      this.logger.warn(`Instance "${context.instance}" not found in config`);
+    }
+    this.logger.info(
+      `Target: ${context.organization}/${context.project}/${context.branch || DEFAULT_BRANCH}:${context.revision || DEFAULT_REVISION}`,
+    );
+    if ((instance?.authMode || 'stored') === 'stored') {
+      this.logger.info(
+        `Credential: ${context.credential || DEFAULT_CREDENTIAL}`,
+      );
+    }
+    this.logger.info(`Config: ${loaded.path}`);
+  }
+}

--- a/src/commands/context/context-use.command.ts
+++ b/src/commands/context/context-use.command.ts
@@ -1,0 +1,31 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+@SubCommand({
+  name: 'use',
+  arguments: '<name>',
+  description: 'Set the current workspace Revisium context',
+})
+export class ContextUseCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(inputs: string[]): Promise<void> {
+    const name = inputs[0];
+    if (!name) {
+      throw new Error('Error: context name is required');
+    }
+
+    const { loaded } = await this.workspaceConfig.loadContext(name);
+
+    loaded.config.currentContext = name;
+    await this.workspaceConfig.save(loaded.path, loaded.config);
+
+    this.logger.success(`Using context "${name}"`);
+  }
+}

--- a/src/commands/context/context.command.ts
+++ b/src/commands/context/context.command.ts
@@ -1,0 +1,28 @@
+import { Command, CommandRunner } from 'nest-commander';
+import { ContextCreateCommand } from './context-create.command';
+import { ContextListCommand } from './context-list.command';
+import { ContextRemoveCommand } from './context-remove.command';
+import { ContextShowCommand } from './context-show.command';
+import { ContextUseCommand } from './context-use.command';
+
+@Command({
+  name: 'context',
+  description: 'Manage workspace Revisium contexts',
+  subCommands: [
+    ContextCreateCommand,
+    ContextListCommand,
+    ContextShowCommand,
+    ContextUseCommand,
+    ContextRemoveCommand,
+  ],
+})
+export class ContextCommand extends CommandRunner {
+  constructor() {
+    super();
+  }
+
+  run(): Promise<void> {
+    this.command.help();
+    return Promise.resolve();
+  }
+}

--- a/src/commands/instance/instance-add.command.ts
+++ b/src/commands/instance/instance-add.command.ts
@@ -1,0 +1,72 @@
+import { CommandRunner, Option, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import {
+  WorkspaceAuthMode,
+  WorkspaceConfigService,
+} from 'src/services/workspace';
+
+interface Options {
+  url?: string;
+  auth?: WorkspaceAuthMode;
+}
+
+@SubCommand({
+  name: 'add',
+  arguments: '<name>',
+  description: 'Add or update a workspace Revisium instance',
+})
+export class InstanceAddCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(inputs: string[], options: Options): Promise<void> {
+    const name = inputs[0];
+    if (!name) {
+      throw new Error('Error: instance name is required');
+    }
+    if (!options.url) {
+      throw new Error('Error: --url option is required');
+    }
+
+    const loaded = await this.workspaceConfig.loadOrCreate();
+    const baseUrl = this.workspaceConfig.normalizeBaseUrl(options.url);
+    const authMode = options.auth || 'stored';
+    const existed = Boolean(loaded.config.instances[name]);
+
+    loaded.config.instances[name] = {
+      baseUrl,
+      authMode,
+    };
+
+    await this.workspaceConfig.save(loaded.path, loaded.config);
+
+    this.logger.success(
+      `${existed ? 'Updated' : 'Added'} instance "${name}" (${baseUrl}, auth: ${authMode})`,
+    );
+    this.logger.info(`Config: ${loaded.path}`);
+  }
+
+  @Option({
+    flags: '--url <url>',
+    description: 'Revisium server URL, for example revisium://localhost:9222',
+    required: true,
+  })
+  parseUrl(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--auth <mode>',
+    description: 'Authentication mode: stored or none',
+  })
+  parseAuth(value: string): WorkspaceAuthMode {
+    if (value !== 'stored' && value !== 'none') {
+      throw new Error('Auth mode must be "stored" or "none"');
+    }
+    return value;
+  }
+}

--- a/src/commands/instance/instance-list.command.ts
+++ b/src/commands/instance/instance-list.command.ts
@@ -1,0 +1,31 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+@SubCommand({
+  name: 'list',
+  description: 'List workspace Revisium instances',
+})
+export class InstanceListCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(): Promise<void> {
+    const loaded = await this.workspaceConfig.load();
+    if (!loaded || Object.keys(loaded.config.instances).length === 0) {
+      this.logger.info('No Revisium instances configured in this workspace.');
+      return;
+    }
+
+    this.logger.info(`Config: ${loaded.path}`);
+    for (const [name, instance] of Object.entries(loaded.config.instances)) {
+      this.logger.info(
+        `${name}\t${instance.baseUrl}\tauth:${instance.authMode || 'stored'}`,
+      );
+    }
+  }
+}

--- a/src/commands/instance/instance-remove.command.ts
+++ b/src/commands/instance/instance-remove.command.ts
@@ -1,0 +1,44 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+@SubCommand({
+  name: 'remove',
+  arguments: '<name>',
+  description: 'Remove a workspace Revisium instance',
+})
+export class InstanceRemoveCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(inputs: string[]): Promise<void> {
+    const name = inputs[0];
+    if (!name) {
+      throw new Error('Error: instance name is required');
+    }
+
+    const loaded = await this.workspaceConfig.load();
+    if (!loaded || !Object.hasOwn(loaded.config.instances, name)) {
+      throw new Error(`Revisium instance "${name}" was not found`);
+    }
+
+    const usedByContexts = Object.entries(loaded.config.contexts)
+      .filter(([, context]) => context.instance === name)
+      .map(([contextName]) => contextName);
+
+    if (usedByContexts.length > 0) {
+      throw new Error(
+        `Cannot remove instance "${name}" because it is used by contexts: ${usedByContexts.join(', ')}`,
+      );
+    }
+
+    delete loaded.config.instances[name];
+    await this.workspaceConfig.save(loaded.path, loaded.config);
+
+    this.logger.success(`Removed instance "${name}"`);
+  }
+}

--- a/src/commands/instance/instance-show.command.ts
+++ b/src/commands/instance/instance-show.command.ts
@@ -1,0 +1,35 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+import { LoggerService } from 'src/services/common';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+@SubCommand({
+  name: 'show',
+  arguments: '<name>',
+  description: 'Show a workspace Revisium instance',
+})
+export class InstanceShowCommand extends CommandRunner {
+  constructor(
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(inputs: string[]): Promise<void> {
+    const name = inputs[0];
+    if (!name) {
+      throw new Error('Error: instance name is required');
+    }
+
+    const loaded = await this.workspaceConfig.load();
+    const instance = loaded?.config.instances[name];
+    if (!loaded || !instance) {
+      throw new Error(`Revisium instance "${name}" was not found`);
+    }
+
+    this.logger.info(`Name: ${name}`);
+    this.logger.info(`Base URL: ${instance.baseUrl}`);
+    this.logger.info(`Auth mode: ${instance.authMode || 'stored'}`);
+    this.logger.info(`Config: ${loaded.path}`);
+  }
+}

--- a/src/commands/instance/instance.command.ts
+++ b/src/commands/instance/instance.command.ts
@@ -1,0 +1,26 @@
+import { Command, CommandRunner } from 'nest-commander';
+import { InstanceAddCommand } from './instance-add.command';
+import { InstanceListCommand } from './instance-list.command';
+import { InstanceRemoveCommand } from './instance-remove.command';
+import { InstanceShowCommand } from './instance-show.command';
+
+@Command({
+  name: 'instance',
+  description: 'Manage workspace Revisium instances',
+  subCommands: [
+    InstanceAddCommand,
+    InstanceListCommand,
+    InstanceShowCommand,
+    InstanceRemoveCommand,
+  ],
+})
+export class InstanceCommand extends CommandRunner {
+  constructor() {
+    super();
+  }
+
+  run(): Promise<void> {
+    this.command.help();
+    return Promise.resolve();
+  }
+}

--- a/src/commands/migration/apply-migrations.command.ts
+++ b/src/commands/migration/apply-migrations.command.ts
@@ -39,6 +39,7 @@ export class ApplyMigrationsCommand extends BaseCommand {
 
     await this.connectionService.connect({
       url: options.url,
+      context: options.context,
       createProject: options.createProject,
     });
 

--- a/src/services/connection/__tests__/api-client.spec.ts
+++ b/src/services/connection/__tests__/api-client.spec.ts
@@ -9,6 +9,30 @@ describe('RevisiumApiClient', () => {
     apiClient = new RevisiumApiClient('http://localhost:8080');
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('authenticate with no auth', () => {
+    it('does not call login methods', async () => {
+      const loginWithTokenSpy = jest.spyOn(apiClient.client, 'loginWithToken');
+      const loginWithApiKeySpy = jest.spyOn(
+        apiClient.client,
+        'loginWithApiKey',
+      );
+      const loginSpy = jest.spyOn(apiClient.client, 'login');
+      const setConfigSpy = jest.spyOn(apiClient.client.client, 'setConfig');
+
+      const result = await apiClient.authenticate({ method: 'none' });
+
+      expect(result).toBe('no auth');
+      expect(loginWithTokenSpy).not.toHaveBeenCalled();
+      expect(loginWithApiKeySpy).not.toHaveBeenCalled();
+      expect(loginSpy).not.toHaveBeenCalled();
+      expect(setConfigSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('authenticateWithApiKey (via authenticate)', () => {
     it('calls loginWithApiKey on the underlying client', async () => {
       const loginWithApiKeySpy = jest
@@ -79,7 +103,8 @@ describe('RevisiumApiClient', () => {
   });
 
   describe('authenticateWithToken (via authenticate)', () => {
-    it('calls loginWithToken on the underlying client', async () => {
+    it('sets bearer token on the underlying client', async () => {
+      const setConfigSpy = jest.spyOn(apiClient.client.client, 'setConfig');
       const loginWithTokenSpy = jest
         .spyOn(apiClient.client, 'loginWithToken')
         .mockImplementation(() => {});
@@ -92,7 +117,13 @@ describe('RevisiumApiClient', () => {
         token: 'jwt-token-123',
       });
 
-      expect(loginWithTokenSpy).toHaveBeenCalledWith('jwt-token-123');
+      expect(loginWithTokenSpy).not.toHaveBeenCalled();
+      expect(setConfigSpy).toHaveBeenCalledWith({
+        auth: undefined,
+        headers: {
+          Authorization: 'Bearer jwt-token-123',
+        },
+      });
       expect(result).toBe('token-user');
     });
 
@@ -114,6 +145,100 @@ describe('RevisiumApiClient', () => {
       });
 
       expect(loginWithApiKeySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('authenticateWithPassword (via authenticate)', () => {
+    it('logs in and stores the returned access token as bearer auth', async () => {
+      const setConfigSpy = jest.spyOn(apiClient.client.client, 'setConfig');
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accessToken: 'jwt-from-login',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+
+      const result = await apiClient.authenticate({
+        method: 'password',
+        username: 'admin',
+        password: 'admin',
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/auth/login',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            emailOrUsername: 'admin',
+            password: 'admin',
+          }),
+        }),
+      );
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      expect(setConfigSpy).toHaveBeenCalledWith({
+        auth: undefined,
+        headers: {
+          Authorization: 'Bearer jwt-from-login',
+        },
+      });
+      expect(result).toBe('admin');
+    });
+
+    it('maps an aborted login request to a timeout error', async () => {
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+      jest.spyOn(global, 'fetch').mockRejectedValue(abortError);
+
+      await expect(
+        apiClient.authenticate({
+          method: 'password',
+          username: 'admin',
+          password: 'admin',
+        }),
+      ).rejects.toThrow('Login request timed out after 10000ms');
+    });
+
+    it('rejects malformed login JSON', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response('not-json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      await expect(
+        apiClient.authenticate({
+          method: 'password',
+          username: 'admin',
+          password: 'admin',
+        }),
+      ).rejects.toThrow('Invalid login response: expected JSON');
+    });
+
+    it('rejects login responses without an access token', async () => {
+      const setConfigSpy = jest.spyOn(apiClient.client.client, 'setConfig');
+      jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ accessToken: '' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      await expect(
+        apiClient.authenticate({
+          method: 'password',
+          username: 'admin',
+          password: 'admin',
+        }),
+      ).rejects.toThrow('Invalid login response: missing accessToken');
+      expect(setConfigSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/connection/__tests__/connection.service.spec.ts
+++ b/src/services/connection/__tests__/connection.service.spec.ts
@@ -3,6 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { ConnectionService } from '../connection.service';
 import { ConnectionFactoryService } from '../connection-factory.service';
 import { UrlBuilderService, RevisiumUrlComplete } from '../../url';
+import { WorkspaceConfigService } from '../../workspace';
+import { LoggerService } from '../../common';
 
 describe('ConnectionService', () => {
   let service: ConnectionService;
@@ -13,7 +15,12 @@ describe('ConnectionService', () => {
   let connectionFactoryFake: {
     createConnection: jest.Mock;
   };
+  let workspaceConfigFake: {
+    load: jest.Mock;
+    resolveConnection: jest.Mock;
+  };
   let configServiceFake: { get: jest.Mock };
+  let loggerServiceFake: { info: jest.Mock };
 
   const mockUrl: RevisiumUrlComplete = {
     baseUrl: 'https://cloud.revisium.io',
@@ -34,8 +41,17 @@ describe('ConnectionService', () => {
       createConnection: jest.fn(),
     };
 
+    workspaceConfigFake = {
+      load: jest.fn().mockResolvedValue(undefined),
+      resolveConnection: jest.fn(),
+    };
+
     configServiceFake = {
       get: jest.fn(),
+    };
+
+    loggerServiceFake = {
+      info: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -44,6 +60,8 @@ describe('ConnectionService', () => {
         { provide: UrlBuilderService, useValue: urlBuilderServiceFake },
         { provide: ConnectionFactoryService, useValue: connectionFactoryFake },
         { provide: ConfigService, useValue: configServiceFake },
+        { provide: WorkspaceConfigService, useValue: workspaceConfigFake },
+        { provide: LoggerService, useValue: loggerServiceFake },
       ],
     }).compile();
 
@@ -118,6 +136,149 @@ describe('ConnectionService', () => {
         'api',
         expect.any(Object),
       );
+    });
+
+    it('uses workspace context when no url or env url is provided', async () => {
+      const workspace = {
+        path: '/repo/.revisium/revisium-cli.config.json',
+        config: {
+          version: 1,
+          currentContext: 'local',
+          instances: {
+            local: {
+              baseUrl: 'http://localhost:9222',
+              authMode: 'none',
+            },
+          },
+          contexts: {
+            local: {
+              instance: 'local',
+              organization: 'admin',
+              project: 'dictionary',
+            },
+          },
+        },
+      };
+      const workspaceUrl = {
+        ...mockUrl,
+        auth: { method: 'none' as const },
+      };
+
+      workspaceConfigFake.load.mockResolvedValue(workspace);
+      workspaceConfigFake.resolveConnection.mockReturnValue(workspaceUrl);
+      connectionFactoryFake.createConnection.mockResolvedValue(
+        createMockConnectionInfo(workspaceUrl),
+      );
+
+      await service.connect({ context: 'local' });
+
+      expect(urlBuilderServiceFake.parseAndComplete).not.toHaveBeenCalled();
+      expect(workspaceConfigFake.resolveConnection).toHaveBeenCalledWith(
+        workspace,
+        'local',
+        expect.any(Object),
+      );
+      expect(connectionFactoryFake.createConnection).toHaveBeenCalledWith(
+        workspaceUrl,
+        { createProject: undefined },
+      );
+      expect(loggerServiceFake.info).toHaveBeenCalledWith(
+        'Using context local (instance: local)',
+      );
+    });
+
+    it('prefers explicit context over REVISIUM_URL', async () => {
+      const workspace = {
+        path: '/repo/.revisium/revisium-cli.config.json',
+        config: {
+          version: 1,
+          currentContext: 'local',
+          instances: {
+            local: {
+              baseUrl: 'http://localhost:9222',
+              authMode: 'stored',
+            },
+          },
+          contexts: {
+            local: {
+              instance: 'local',
+              organization: 'admin',
+              project: 'dictionary',
+            },
+          },
+        },
+      };
+      const workspaceUrl = {
+        ...mockUrl,
+        auth: { method: 'token' as const, token: 'env-token' },
+      };
+
+      configServiceFake.get
+        .mockReturnValueOnce('revisium://env-host/admin/env-project')
+        .mockReturnValueOnce('env-token')
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce(undefined);
+      workspaceConfigFake.load.mockResolvedValue(workspace);
+      workspaceConfigFake.resolveConnection.mockReturnValue(workspaceUrl);
+      connectionFactoryFake.createConnection.mockResolvedValue(
+        createMockConnectionInfo(workspaceUrl),
+      );
+
+      await service.connect({ context: 'local' });
+
+      expect(urlBuilderServiceFake.parseAndComplete).not.toHaveBeenCalled();
+      expect(workspaceConfigFake.resolveConnection).toHaveBeenCalledWith(
+        workspace,
+        'local',
+        {
+          url: 'revisium://env-host/admin/env-project',
+          token: 'env-token',
+          apikey: undefined,
+          username: undefined,
+          password: undefined,
+        },
+      );
+      expect(loggerServiceFake.info).toHaveBeenCalledWith(
+        'Using context local (instance: local)',
+      );
+    });
+
+    it('prefers explicit url over workspace context', async () => {
+      const testUrl = 'revisium://test.com/org/proj';
+
+      workspaceConfigFake.load.mockResolvedValue({
+        path: '/repo/.revisium/revisium-cli.config.json',
+        config: {
+          version: 1,
+          currentContext: 'local',
+          instances: {},
+          contexts: {},
+        },
+      });
+      urlBuilderServiceFake.parseAndComplete.mockRejectedValue(
+        new Error('test error'),
+      );
+
+      await expect(
+        service.connect({ url: testUrl, context: 'local' }),
+      ).rejects.toThrow();
+
+      expect(workspaceConfigFake.load).not.toHaveBeenCalled();
+      expect(loggerServiceFake.info).not.toHaveBeenCalled();
+      expect(urlBuilderServiceFake.parseAndComplete).toHaveBeenCalledWith(
+        testUrl,
+        'api',
+        expect.any(Object),
+      );
+    });
+
+    it('fails when context is provided without workspace config', async () => {
+      await expect(service.connect({ context: 'missing' })).rejects.toThrow(
+        'No Revisium workspace config found for context "missing"',
+      );
+
+      expect(urlBuilderServiceFake.parseAndComplete).not.toHaveBeenCalled();
     });
 
     it('passes env config to parseAndComplete', async () => {

--- a/src/services/connection/api-client.ts
+++ b/src/services/connection/api-client.ts
@@ -1,7 +1,13 @@
 import { RevisiumClient } from '@revisium/client';
 import { AuthCredentials } from '../url';
 
+interface LoginResponse {
+  accessToken: string;
+}
+
 export class RevisiumApiClient {
+  private static readonly LOGIN_TIMEOUT_MS = 10000;
+
   public readonly client: RevisiumClient;
 
   constructor(baseUrl: string) {
@@ -9,6 +15,10 @@ export class RevisiumApiClient {
   }
 
   public async authenticate(auth: AuthCredentials): Promise<string> {
+    if (auth.method === 'none') {
+      return 'no auth';
+    }
+
     if (auth.method === 'token') {
       if (!auth.token) {
         throw new Error('Token is required for token authentication');
@@ -32,7 +42,7 @@ export class RevisiumApiClient {
   }
 
   private async authenticateWithToken(token: string): Promise<string> {
-    this.client.loginWithToken(token);
+    this.useBearerToken(token);
     const me = await this.client.me();
     return me.username || 'authenticated user';
   }
@@ -51,7 +61,76 @@ export class RevisiumApiClient {
     username: string,
     password: string,
   ): Promise<string> {
-    await this.client.login(username, password);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      RevisiumApiClient.LOGIN_TIMEOUT_MS,
+    );
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.client.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ emailOrUsername: username, password }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (this.isAbortError(error)) {
+        throw new Error(
+          `Login request timed out after ${RevisiumApiClient.LOGIN_TIMEOUT_MS}ms`,
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `Login failed with status ${response.status}`);
+    }
+
+    const data = await this.parseLoginResponse(response);
+    this.useBearerToken(data.accessToken);
     return username;
+  }
+
+  private async parseLoginResponse(response: Response): Promise<LoginResponse> {
+    let data: unknown;
+
+    try {
+      data = await response.json();
+    } catch {
+      throw new Error('Invalid login response: expected JSON');
+    }
+
+    if (
+      typeof data !== 'object' ||
+      data === null ||
+      !('accessToken' in data) ||
+      typeof data.accessToken !== 'string' ||
+      data.accessToken.trim() === ''
+    ) {
+      throw new Error('Invalid login response: missing accessToken');
+    }
+
+    return { accessToken: data.accessToken };
+  }
+
+  private isAbortError(error: unknown): boolean {
+    return error instanceof Error && error.name === 'AbortError';
+  }
+
+  private useBearerToken(token: string): void {
+    // JWTs must be sent as Bearer tokens. The generated client auth helper
+    // currently routes token input through X-Api-Key first, which standalone rejects.
+    // API keys intentionally keep loginWithApiKey() so they still use X-Api-Key.
+    this.client.client.setConfig({
+      auth: undefined,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
   }
 }

--- a/src/services/connection/connection.service.ts
+++ b/src/services/connection/connection.service.ts
@@ -5,12 +5,15 @@ import {
   ConnectionFactoryService,
   ConnectionInfo,
 } from './connection-factory.service';
-import { UrlBuilderService, UrlEnvConfig } from '../url';
+import { LoggerService } from '../common';
+import { RevisiumUrlComplete, UrlBuilderService, UrlEnvConfig } from '../url';
+import { LoadedWorkspaceConfig, WorkspaceConfigService } from '../workspace';
 
 export { ConnectionInfo } from './connection-factory.service';
 
 export interface ConnectionOptions {
   url?: string;
+  context?: string;
   createProject?: boolean;
 }
 
@@ -22,6 +25,8 @@ export class ConnectionService {
     private readonly configService: ConfigService,
     private readonly urlBuilder: UrlBuilderService,
     private readonly connectionFactory: ConnectionFactoryService,
+    private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly logger: LoggerService,
   ) {}
 
   public get connection(): ConnectionInfo {
@@ -37,11 +42,72 @@ export class ConnectionService {
 
   public async connect(options: ConnectionOptions = {}): Promise<void> {
     const env = this.getEnvConfig();
-    const url = await this.urlBuilder.parseAndComplete(options.url, 'api', env);
+    const url = await this.resolveUrl(options, env);
 
     this._connection = await this.connectionFactory.createConnection(url, {
       createProject: options.createProject,
     });
+  }
+
+  private async resolveUrl(
+    options: ConnectionOptions,
+    env: UrlEnvConfig,
+  ): Promise<RevisiumUrlComplete> {
+    if (options.url) {
+      return this.urlBuilder.parseAndComplete(options.url, 'api', env);
+    }
+
+    if (options.context) {
+      const workspace = await this.workspaceConfig.load();
+      if (!workspace) {
+        throw new Error(
+          `No Revisium workspace config found for context "${options.context}". Run: revisium instance add <instance> --url <revisium-server-url>, then revisium context create ${options.context} --instance <instance> --org <org> --project <project>`,
+        );
+      }
+      const url = this.workspaceConfig.resolveConnection(
+        workspace,
+        options.context,
+        env,
+      );
+      this.logWorkspaceContext(workspace, options.context);
+      return url;
+    }
+
+    if (env.url) {
+      return this.urlBuilder.parseAndComplete(undefined, 'api', env);
+    }
+
+    const workspace = await this.workspaceConfig.load();
+    if (workspace) {
+      const url = this.workspaceConfig.resolveConnection(
+        workspace,
+        undefined,
+        env,
+      );
+      this.logWorkspaceContext(workspace);
+      return url;
+    }
+
+    return this.urlBuilder.parseAndComplete(undefined, 'api', env);
+  }
+
+  private logWorkspaceContext(
+    loaded: LoadedWorkspaceConfig,
+    contextName?: string,
+  ): void {
+    const selectedContext = contextName || loaded.config.currentContext;
+    if (!selectedContext) {
+      return;
+    }
+
+    const context = loaded.config.contexts[selectedContext];
+    if (!context) {
+      return;
+    }
+
+    this.logger.info(
+      `Using context ${selectedContext} (instance: ${context.instance})`,
+    );
   }
 
   private getEnvConfig(): UrlEnvConfig {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,3 +2,4 @@ export * from './connection';
 export * from './url';
 export * from './sync';
 export * from './common';
+export * from './workspace';

--- a/src/services/url/__tests__/url-builder.service.spec.ts
+++ b/src/services/url/__tests__/url-builder.service.spec.ts
@@ -508,6 +508,23 @@ describe('UrlBuilderService', () => {
       );
     });
 
+    it('formats URL with no auth', () => {
+      const url = {
+        baseUrl: 'http://localhost:9222',
+        auth: {
+          method: 'none' as const,
+        },
+        organization: 'admin',
+        project: 'dictionary',
+        branch: 'master',
+        revision: 'draft',
+      };
+
+      expect(service.formatAsRevisiumUrl(url)).toBe(
+        'revisium://localhost:9222/admin/dictionary/master',
+      );
+    });
+
     it('formats URL with revision', () => {
       const url = {
         baseUrl: 'https://cloud.revisium.io',

--- a/src/services/url/auth-prompt.service.ts
+++ b/src/services/url/auth-prompt.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InteractiveService } from '../common';
 
-export type AuthMethod = 'token' | 'apikey' | 'password';
+export type AuthMethod = 'none' | 'token' | 'apikey' | 'password';
 
 export type AuthCredentials =
+  | { method: 'none' }
   | { method: 'token'; token: string }
   | { method: 'apikey'; apikey: string }
   | { method: 'password'; username: string; password: string };
@@ -26,6 +27,10 @@ export class AuthPromptService {
         { name: 'Username & Password', value: 'password' },
       ],
     );
+
+    if (authMethod === 'none') {
+      return { method: 'none' };
+    }
 
     if (authMethod === 'token') {
       const token = await this.interactive.promptPassword(

--- a/src/services/url/url-builder.service.ts
+++ b/src/services/url/url-builder.service.ts
@@ -46,6 +46,10 @@ export class UrlBuilderService {
 
     const basePath = `revisium://${baseUrlWithoutProtocol}/${url.organization}/${url.project}${branchPart}`;
 
+    if (url.auth.method === 'none') {
+      return basePath;
+    }
+
     if (url.auth.method === 'token') {
       const tokenValue = maskSecrets ? '****' : url.auth.token;
       return `${basePath}?token=${tokenValue}`;

--- a/src/services/workspace/__tests__/workspace-config.service.spec.ts
+++ b/src/services/workspace/__tests__/workspace-config.service.spec.ts
@@ -1,0 +1,250 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { WorkspaceConfigService } from '../workspace-config.service';
+import { UrlParserService } from '../../url/url-parser.service';
+
+describe('WorkspaceConfigService', () => {
+  let service: WorkspaceConfigService;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    service = new WorkspaceConfigService(new UrlParserService());
+    tempDir = await mkdtemp(join(tmpdir(), 'revisium-cli-workspace-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes and discovers the nearest workspace config from a child folder', async () => {
+    const loaded = await service.loadOrCreate(tempDir);
+    loaded.config.instances.local = {
+      baseUrl: 'http://localhost:9222',
+      authMode: 'none',
+    };
+    await service.save(loaded.path, loaded.config);
+
+    const childDir = join(tempDir, 'examples', 'dictionary');
+    await mkdir(childDir, { recursive: true });
+
+    const discovered = await service.load(childDir);
+
+    expect(discovered?.path).toBe(loaded.path);
+    expect(discovered?.config.instances.local).toEqual({
+      baseUrl: 'http://localhost:9222',
+      authMode: 'none',
+    });
+  });
+
+  it('normalizes revisium URLs to server base URLs', () => {
+    expect(
+      service.normalizeBaseUrl('revisium://localhost:9222/admin/proj'),
+    ).toBe('http://localhost:9222');
+    expect(service.normalizeBaseUrl('https://cloud.revisium.io/')).toBe(
+      'https://cloud.revisium.io',
+    );
+  });
+
+  it('rejects direct http instance URLs with missing host or extra target path', () => {
+    expect(() => service.normalizeBaseUrl('https://')).toThrow(
+      'Use http(s)://host[:port]',
+    );
+    expect(() =>
+      service.normalizeBaseUrl('https://cloud.revisium.io/admin/dictionary'),
+    ).toThrow('Use http(s)://host[:port]');
+    expect(() =>
+      service.normalizeBaseUrl('https://cloud.revisium.io?token=secret'),
+    ).toThrow('Use http(s)://host[:port]');
+  });
+
+  it('parses context URLs with default branch and revision', () => {
+    expect(
+      service.parseContextUrl('revisium://localhost:9222/admin/dictionary'),
+    ).toEqual({
+      baseUrl: 'http://localhost:9222',
+      organization: 'admin',
+      project: 'dictionary',
+      branch: 'master',
+      revision: 'draft',
+    });
+  });
+
+  it('resolves no-auth workspace contexts', () => {
+    const url = service.resolveConnection(
+      {
+        path: join(tempDir, '.revisium', 'revisium-cli.config.json'),
+        config: {
+          version: 1,
+          currentContext: 'dictionary-local',
+          instances: {
+            local: {
+              baseUrl: 'http://localhost:9222',
+              authMode: 'none',
+            },
+          },
+          contexts: {
+            'dictionary-local': {
+              instance: 'local',
+              organization: 'admin',
+              project: 'dictionary',
+            },
+          },
+        },
+      },
+      undefined,
+      {},
+    );
+
+    expect(url).toEqual({
+      baseUrl: 'http://localhost:9222',
+      auth: { method: 'none' },
+      organization: 'admin',
+      project: 'dictionary',
+      branch: 'master',
+      revision: 'draft',
+    });
+  });
+
+  it('loads an existing context with its config path', async () => {
+    const loaded = await service.loadOrCreate(tempDir);
+    loaded.config.contexts.demo = {
+      instance: 'local',
+      organization: 'admin',
+      project: 'dictionary',
+    };
+    await service.save(loaded.path, loaded.config);
+
+    const result = await service.loadContext('demo', tempDir);
+
+    expect(result.loaded.path).toBe(loaded.path);
+    expect(result.context.project).toBe('dictionary');
+  });
+
+  it('fails when loading a missing context', async () => {
+    const loaded = await service.loadOrCreate(tempDir);
+    await service.save(loaded.path, loaded.config);
+
+    await expect(service.loadContext('missing', tempDir)).rejects.toThrow(
+      'Revisium context "missing" was not found',
+    );
+  });
+
+  it('lets environment credentials override no-auth mode', () => {
+    const url = service.resolveConnection(
+      {
+        path: join(tempDir, '.revisium', 'revisium-cli.config.json'),
+        config: {
+          version: 1,
+          currentContext: 'dictionary-local',
+          instances: {
+            local: {
+              baseUrl: 'http://localhost:9222',
+              authMode: 'none',
+            },
+          },
+          contexts: {
+            'dictionary-local': {
+              instance: 'local',
+              organization: 'admin',
+              project: 'dictionary',
+            },
+          },
+        },
+      },
+      undefined,
+      { apikey: 'rev_test' },
+    );
+
+    expect(url.auth).toEqual({ method: 'apikey', apikey: 'rev_test' });
+  });
+
+  it('fails with remediation when stored credentials are required', () => {
+    expect(() =>
+      service.resolveConnection(
+        {
+          path: join(tempDir, '.revisium', 'revisium-cli.config.json'),
+          config: {
+            version: 1,
+            currentContext: 'cloud',
+            instances: {
+              cloud: {
+                baseUrl: 'https://cloud.revisium.io',
+                authMode: 'stored',
+              },
+            },
+            contexts: {
+              cloud: {
+                instance: 'cloud',
+                credential: 'admin',
+                organization: 'admin',
+                project: 'dictionary',
+              },
+            },
+          },
+        },
+        undefined,
+        {},
+      ),
+    ).toThrow(
+      'No credentials found for context "cloud" credential "admin". Set REVISIUM_API_KEY=...',
+    );
+  });
+
+  it('rejects malformed config files', async () => {
+    const configPath = service.getDefaultConfigPath(tempDir);
+    await mkdir(join(tempDir, '.revisium'), { recursive: true });
+    await writeFile(configPath, '{"version":2}', 'utf-8');
+
+    await expect(service.load(tempDir)).rejects.toThrow(
+      'unsupported version 2',
+    );
+  });
+
+  it('normalizes instance base URLs when loading config files', async () => {
+    const configPath = service.getDefaultConfigPath(tempDir);
+    await mkdir(join(tempDir, '.revisium'), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        version: 1,
+        instances: {
+          cloud: {
+            baseUrl: 'https://cloud.revisium.io/',
+            authMode: 'stored',
+          },
+        },
+        contexts: {},
+      }),
+      'utf-8',
+    );
+
+    const loaded = await service.load(tempDir);
+
+    expect(loaded?.config.instances.cloud.baseUrl).toBe(
+      'https://cloud.revisium.io',
+    );
+  });
+
+  it('writes only the workspace config file when saving', async () => {
+    const loaded = await service.loadOrCreate(tempDir);
+    loaded.config.instances.local = {
+      baseUrl: 'http://localhost:9222',
+      authMode: 'none',
+    };
+
+    await service.save(loaded.path, loaded.config);
+
+    const raw = await readFile(loaded.path, 'utf-8');
+    expect(JSON.parse(raw)).toEqual({
+      version: 1,
+      instances: {
+        local: {
+          baseUrl: 'http://localhost:9222',
+          authMode: 'none',
+        },
+      },
+      contexts: {},
+    });
+  });
+});

--- a/src/services/workspace/index.ts
+++ b/src/services/workspace/index.ts
@@ -1,0 +1,14 @@
+export {
+  DEFAULT_BRANCH,
+  DEFAULT_CREDENTIAL,
+  DEFAULT_REVISION,
+  LoadedWorkspaceContext,
+  LoadedWorkspaceConfig,
+  WORKSPACE_CONFIG_DIR,
+  WORKSPACE_CONFIG_FILE,
+  WorkspaceAuthMode,
+  WorkspaceConfig,
+  WorkspaceConfigService,
+  WorkspaceContextConfig,
+  WorkspaceInstanceConfig,
+} from './workspace-config.service';

--- a/src/services/workspace/workspace-config.service.ts
+++ b/src/services/workspace/workspace-config.service.ts
@@ -1,0 +1,425 @@
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, parse, resolve } from 'node:path';
+import { Injectable } from '@nestjs/common';
+import {
+  AuthCredentials,
+  RevisiumUrlComplete,
+  UrlEnvConfig,
+} from 'src/services/url';
+import { UrlParserService } from 'src/services/url/url-parser.service';
+
+export const WORKSPACE_CONFIG_DIR = '.revisium';
+export const WORKSPACE_CONFIG_FILE = 'revisium-cli.config.json';
+export const DEFAULT_BRANCH = 'master';
+export const DEFAULT_REVISION = 'draft';
+export const DEFAULT_CREDENTIAL = 'default';
+
+export type WorkspaceAuthMode = 'none' | 'stored';
+
+export interface WorkspaceInstanceConfig {
+  baseUrl: string;
+  authMode?: WorkspaceAuthMode;
+}
+
+export interface WorkspaceContextConfig {
+  instance: string;
+  credential?: string;
+  organization: string;
+  project: string;
+  branch?: string;
+  revision?: string;
+}
+
+export interface WorkspaceConfig {
+  version: 1;
+  currentContext?: string;
+  instances: Record<string, WorkspaceInstanceConfig>;
+  contexts: Record<string, WorkspaceContextConfig>;
+}
+
+export interface LoadedWorkspaceConfig {
+  path: string;
+  config: WorkspaceConfig;
+}
+
+export interface LoadedWorkspaceContext {
+  loaded: LoadedWorkspaceConfig;
+  context: WorkspaceContextConfig;
+}
+
+@Injectable()
+export class WorkspaceConfigService {
+  constructor(private readonly urlParser: UrlParserService) {}
+
+  async load(
+    startDir = process.cwd(),
+  ): Promise<LoadedWorkspaceConfig | undefined> {
+    const configPath = await this.findConfigPath(startDir);
+    if (!configPath) {
+      return undefined;
+    }
+
+    const raw = await readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+
+    return {
+      path: configPath,
+      config: this.normalizeConfig(parsed, configPath),
+    };
+  }
+
+  async loadOrCreate(startDir = process.cwd()): Promise<LoadedWorkspaceConfig> {
+    const loaded = await this.load(startDir);
+    if (loaded) {
+      return loaded;
+    }
+
+    return {
+      path: this.getDefaultConfigPath(startDir),
+      config: this.createEmptyConfig(),
+    };
+  }
+
+  async save(path: string, config: WorkspaceConfig): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+  }
+
+  async loadContext(
+    name: string,
+    startDir = process.cwd(),
+  ): Promise<LoadedWorkspaceContext> {
+    const loaded = await this.load(startDir);
+    if (!loaded || !Object.hasOwn(loaded.config.contexts, name)) {
+      throw new Error(`Revisium context "${name}" was not found`);
+    }
+
+    return {
+      loaded,
+      context: loaded.config.contexts[name],
+    };
+  }
+
+  async findConfigPath(startDir = process.cwd()): Promise<string | undefined> {
+    let currentDir = resolve(startDir);
+    const root = parse(currentDir).root;
+
+    while (true) {
+      const candidate = this.getDefaultConfigPath(currentDir);
+      if (await this.exists(candidate)) {
+        return candidate;
+      }
+
+      if (currentDir === root) {
+        return undefined;
+      }
+
+      currentDir = dirname(currentDir);
+    }
+  }
+
+  getDefaultConfigPath(startDir = process.cwd()): string {
+    return join(resolve(startDir), WORKSPACE_CONFIG_DIR, WORKSPACE_CONFIG_FILE);
+  }
+
+  createEmptyConfig(): WorkspaceConfig {
+    return {
+      version: 1,
+      instances: {},
+      contexts: {},
+    };
+  }
+
+  normalizeBaseUrl(input: string): string {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      throw new Error('Instance URL cannot be empty');
+    }
+
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+      return this.normalizeHttpBaseUrl(trimmed, input);
+    }
+
+    const parsed = this.urlParser.parse(trimmed);
+    if (!parsed.baseUrl) {
+      throw new Error(
+        `Could not parse instance URL "${input}". Use revisium://host[:port]`,
+      );
+    }
+
+    return this.stripTrailingSlashes(parsed.baseUrl);
+  }
+
+  parseContextUrl(input: string): {
+    baseUrl: string;
+    organization: string;
+    project: string;
+    branch: string;
+    revision: string;
+  } {
+    const parsed = this.urlParser.parse(input);
+
+    if (!parsed.baseUrl || !parsed.organization || !parsed.project) {
+      throw new Error(
+        'Context URL must include host, organization, and project: revisium://host/org/project/branch[:revision]',
+      );
+    }
+
+    return {
+      baseUrl: this.stripTrailingSlashes(parsed.baseUrl),
+      organization: parsed.organization,
+      project: parsed.project,
+      branch: parsed.branch || DEFAULT_BRANCH,
+      revision: parsed.revision || DEFAULT_REVISION,
+    };
+  }
+
+  findInstanceNameByBaseUrl(
+    config: WorkspaceConfig,
+    baseUrl: string,
+  ): string | undefined {
+    const matches = Object.entries(config.instances)
+      .filter(([, instance]) => instance.baseUrl === baseUrl)
+      .map(([name]) => name);
+
+    if (matches.length > 1) {
+      throw new Error(
+        `Multiple instances use ${baseUrl}. Pass --instance to choose one.`,
+      );
+    }
+
+    return matches[0];
+  }
+
+  resolveConnection(
+    loaded: LoadedWorkspaceConfig,
+    contextName: string | undefined,
+    env: UrlEnvConfig,
+  ): RevisiumUrlComplete {
+    const selectedContext = contextName || loaded.config.currentContext;
+
+    if (!selectedContext) {
+      throw new Error(
+        `No current Revisium context is configured in ${loaded.path}. Run: revisium context use <name>`,
+      );
+    }
+
+    const context = loaded.config.contexts[selectedContext];
+    if (!context) {
+      throw new Error(
+        `Revisium context "${selectedContext}" was not found in ${loaded.path}`,
+      );
+    }
+
+    const instance = loaded.config.instances[context.instance];
+    if (!instance) {
+      throw new Error(
+        `Revisium instance "${context.instance}" for context "${selectedContext}" was not found in ${loaded.path}`,
+      );
+    }
+
+    return {
+      baseUrl: instance.baseUrl,
+      auth: this.resolveAuth(instance, context, selectedContext, env),
+      organization: context.organization,
+      project: context.project,
+      branch: context.branch || DEFAULT_BRANCH,
+      revision: context.revision || DEFAULT_REVISION,
+    };
+  }
+
+  private resolveAuth(
+    instance: WorkspaceInstanceConfig,
+    context: WorkspaceContextConfig,
+    contextName: string,
+    env: UrlEnvConfig,
+  ): AuthCredentials {
+    const envAuth = this.resolveEnvAuth(env);
+    if (envAuth) {
+      return envAuth;
+    }
+
+    if ((instance.authMode || 'stored') === 'none') {
+      return { method: 'none' };
+    }
+
+    const credential = context.credential || DEFAULT_CREDENTIAL;
+    throw new Error(
+      `No credentials found for context "${contextName}" credential "${credential}". ` +
+        'Set REVISIUM_API_KEY=... or REVISIUM_TOKEN=..., or configure the instance with authMode "none" for local standalone.',
+    );
+  }
+
+  private resolveEnvAuth(env: UrlEnvConfig): AuthCredentials | undefined {
+    const methods: string[] = [];
+
+    if (env.token) {
+      methods.push('token');
+    }
+    if (env.apikey) {
+      methods.push('apikey');
+    }
+    if (env.username || env.password) {
+      if (!env.username || !env.password) {
+        throw new Error(
+          'Both REVISIUM_USERNAME and REVISIUM_PASSWORD are required for password authentication',
+        );
+      }
+      methods.push('credentials');
+    }
+
+    if (methods.length > 1) {
+      throw new Error(
+        `Multiple authentication methods specified: ${methods.join(', ')}. ` +
+          'Use only one: token, apikey, or username/password',
+      );
+    }
+
+    if (env.token) {
+      return { method: 'token', token: env.token };
+    }
+    if (env.apikey) {
+      return { method: 'apikey', apikey: env.apikey };
+    }
+    if (env.username && env.password) {
+      return {
+        method: 'password',
+        username: env.username,
+        password: env.password,
+      };
+    }
+
+    return undefined;
+  }
+
+  private normalizeConfig(value: unknown, path: string): WorkspaceConfig {
+    if (!this.isObject(value)) {
+      throw new TypeError(
+        `Invalid Revisium CLI config at ${path}: expected object`,
+      );
+    }
+
+    const version = value.version;
+    if (version !== 1) {
+      throw new Error(
+        `Invalid Revisium CLI config at ${path}: unsupported version ${String(version)}`,
+      );
+    }
+
+    const instances = this.normalizeRecord<WorkspaceInstanceConfig>(
+      value.instances,
+      'instances',
+      path,
+    );
+    const contexts = this.normalizeRecord<WorkspaceContextConfig>(
+      value.contexts,
+      'contexts',
+      path,
+    );
+
+    for (const [name, instance] of Object.entries(instances)) {
+      if (!this.isObject(instance) || typeof instance.baseUrl !== 'string') {
+        throw new TypeError(
+          `Invalid Revisium CLI config at ${path}: instance "${name}" must include baseUrl`,
+        );
+      }
+      instance.baseUrl = this.normalizeBaseUrl(instance.baseUrl);
+      if (
+        instance.authMode !== undefined &&
+        instance.authMode !== 'none' &&
+        instance.authMode !== 'stored'
+      ) {
+        throw new Error(
+          `Invalid Revisium CLI config at ${path}: instance "${name}" has unsupported authMode`,
+        );
+      }
+    }
+
+    for (const [name, context] of Object.entries(contexts)) {
+      if (
+        !this.isObject(context) ||
+        typeof context.instance !== 'string' ||
+        typeof context.organization !== 'string' ||
+        typeof context.project !== 'string'
+      ) {
+        throw new TypeError(
+          `Invalid Revisium CLI config at ${path}: context "${name}" must include instance, organization, and project`,
+        );
+      }
+    }
+
+    return {
+      version: 1,
+      currentContext:
+        typeof value.currentContext === 'string'
+          ? value.currentContext
+          : undefined,
+      instances,
+      contexts,
+    };
+  }
+
+  private normalizeRecord<T>(
+    value: unknown,
+    key: string,
+    path: string,
+  ): Record<string, T> {
+    if (value === undefined) {
+      return {};
+    }
+    if (!this.isObject(value)) {
+      throw new TypeError(
+        `Invalid Revisium CLI config at ${path}: ${key} must be an object`,
+      );
+    }
+    return value as Record<string, T>;
+  }
+
+  private isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  private stripTrailingSlashes(value: string): string {
+    let endIndex = value.length;
+    while (endIndex > 0 && value[endIndex - 1] === '/') {
+      endIndex--;
+    }
+    return value.slice(0, endIndex);
+  }
+
+  private normalizeHttpBaseUrl(value: string, originalInput: string): string {
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      throw new Error(
+        `Could not parse instance URL "${originalInput}". Use http(s)://host[:port]`,
+      );
+    }
+
+    const hasPath = parsed.pathname !== '' && parsed.pathname !== '/';
+    if (
+      !parsed.hostname ||
+      parsed.username ||
+      parsed.password ||
+      hasPath ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      throw new Error(
+        `Could not parse instance URL "${originalInput}". Use http(s)://host[:port]`,
+      );
+    }
+
+    return `${parsed.protocol}//${parsed.host}`;
+  }
+
+  private async exists(path: string): Promise<boolean> {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: new workspace-scoped instance/context commands (add/list/show/remove; create/list/show/use/remove), a --context option, and workspace-local config allowing omission of --url for single-target commands; explicit local "no auth" standalone mode.

* **Documentation**
  * Added Workspace Config guide; updated authentication and configuration docs with no-auth guidance and clarified target/auth precedence.

* **Tests**
  * Extensive new e2e and unit tests covering workspace config, auth modes, context precedence, and schema/save flows.

* **Chores**
  * Development dependency for standalone test helper bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->