### PR TITLE
feat: add example bootstrap commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,20 +133,23 @@ revisium sync all \
 
 ## Commands
 
-| Command                               | Description                         | Documentation                                |
-| ------------------------------------- | ----------------------------------- | -------------------------------------------- |
-| `schema save`                         | Export table schemas to JSON files  | [Schema Commands](docs/schema-commands.md)   |
-| `schema create-migrations`            | Convert schemas to migration format | [Schema Commands](docs/schema-commands.md)   |
-| `migrate save`                        | Export migrations to JSON file      | [Migrate Commands](docs/migrate-commands.md) |
-| `migrate apply`                       | Apply migrations from JSON file     | [Migrate Commands](docs/migrate-commands.md) |
-| `rows save`                           | Export table data to JSON files     | [Rows Commands](docs/rows-commands.md)       |
-| `rows upload`                         | Upload table data from JSON files   | [Rows Commands](docs/rows-commands.md)       |
-| `sync schema`                         | Sync schema between projects        | [Sync Commands](docs/sync-commands.md)       |
-| `sync data`                           | Sync data between projects          | [Sync Commands](docs/sync-commands.md)       |
-| `sync all`                            | Full sync (schema + data)           | [Sync Commands](docs/sync-commands.md)       |
-| `instance add/list/show/remove`       | Manage workspace Revisium instances | [Workspace Config](docs/workspace-config.md) |
-| `context create/list/show/use/remove` | Manage workspace Revisium contexts  | [Workspace Config](docs/workspace-config.md) |
-| `auth login/status/logout`            | Manage saved API-key credentials    | [Authentication](docs/authentication.md)     |
+| Command                               | Description                            | Documentation                                    |
+| ------------------------------------- | -------------------------------------- | ------------------------------------------------ |
+| `schema save`                         | Export table schemas to JSON files     | [Schema Commands](docs/schema-commands.md)       |
+| `schema create-migrations`            | Convert schemas to migration format    | [Schema Commands](docs/schema-commands.md)       |
+| `migrate save`                        | Export migrations to JSON file         | [Migrate Commands](docs/migrate-commands.md)     |
+| `migrate apply`                       | Apply migrations from JSON file        | [Migrate Commands](docs/migrate-commands.md)     |
+| `rows save`                           | Export table data to JSON files        | [Rows Commands](docs/rows-commands.md)           |
+| `rows upload`                         | Upload table data from JSON files      | [Rows Commands](docs/rows-commands.md)           |
+| `sync schema`                         | Sync schema between projects           | [Sync Commands](docs/sync-commands.md)           |
+| `sync data`                           | Sync data between projects             | [Sync Commands](docs/sync-commands.md)           |
+| `sync all`                            | Full sync (schema + data)              | [Sync Commands](docs/sync-commands.md)           |
+| `instance add/list/show/remove`       | Manage workspace Revisium instances    | [Workspace Config](docs/workspace-config.md)     |
+| `context create/list/show/use/remove` | Manage workspace Revisium contexts     | [Workspace Config](docs/workspace-config.md)     |
+| `auth login/status/logout`            | Manage saved API-key credentials       | [Authentication](docs/authentication.md)         |
+| `project ensure`                      | Ensure a project and branch exist      | [Bootstrap Commands](docs/bootstrap-commands.md) |
+| `endpoint ensure/list`                | Ensure or list generated endpoints     | [Bootstrap Commands](docs/bootstrap-commands.md) |
+| `example bootstrap`                   | Bootstrap example projects from config | [Bootstrap Commands](docs/bootstrap-commands.md) |
 
 ## Configuration
 
@@ -192,6 +195,7 @@ See [Configuration](docs/configuration.md) and [URL Format](docs/url-format.md) 
 
 - [Configuration](docs/configuration.md) - Environment variables and .env files
 - [Workspace Config](docs/workspace-config.md) - non-secret instances and contexts
+- [Bootstrap Commands](docs/bootstrap-commands.md) - project, endpoint, and example bootstrap workflows
 - [URL Format](docs/url-format.md) - Revisium URL syntax
 - [Authentication](docs/authentication.md) - Token, API key, and password auth
 - [Auth Contexts And Bootstrap Plan](docs/auth-contexts-and-bootstrap-plan.md) - implementation tracker for saved auth, contexts, and example bootstrap workflow

--- a/docs/bootstrap-commands.md
+++ b/docs/bootstrap-commands.md
@@ -1,0 +1,105 @@
+# Bootstrap Commands
+
+Bootstrap commands help example repositories create the Revisium resources they need without custom Node scripts.
+
+## Project Ensure
+
+```bash
+revisium project ensure \
+  --url revisium://localhost:9222/admin/dictionary/master
+```
+
+Behavior:
+
+- Creates the project when it is missing.
+- Creates the target branch when the project exists but the branch is missing.
+- Exits successfully when both project and branch already exist.
+- Uses the Revisium URL format by default.
+- Supports `--dry-run` and `--json` for scripted setup.
+
+You can also use a workspace context:
+
+```bash
+revisium project ensure --context dictionary-local
+```
+
+## Endpoint Ensure
+
+```bash
+revisium endpoint ensure \
+  --url revisium://localhost:9222/admin/dictionary/master \
+  --type REST_API
+
+revisium endpoint ensure \
+  --url revisium://localhost:9222/admin/dictionary/master \
+  --type GRAPHQL
+```
+
+Behavior:
+
+- Creates the endpoint when the selected revision does not already have one of that type.
+- Skips existing endpoints, so reruns do not create duplicates.
+- Prints endpoint id, type, selected revision, and a best-effort URL hint.
+- Supports `--dry-run` and `--json` for scripted setup.
+
+List endpoints:
+
+```bash
+revisium endpoint list --url revisium://localhost:9222/admin/dictionary/master
+revisium endpoint list --url revisium://localhost:9222/admin/dictionary/master --json
+```
+
+## Example Bootstrap
+
+```bash
+revisium example bootstrap \
+  --config ./bootstrap.config.json \
+  --url revisium://localhost:9222/admin/dictionary/master \
+  --commit
+```
+
+Config shape:
+
+```json
+{
+  "projectName": "dictionary",
+  "branchName": "master",
+  "endpoints": ["REST_API", "GRAPHQL"],
+  "tables": [
+    { "id": "FaqCategory", "schema": { "type": "object" } }
+  ],
+  "rows": [
+    { "tableId": "FaqCategory", "rowId": "billing", "data": { "name": "Billing" } }
+  ],
+  "commitMessage": "Bootstrap dictionary example"
+}
+```
+
+Behavior:
+
+- Ensures the project and branch exist.
+- Creates missing tables.
+- Creates missing rows.
+- Creates missing endpoints.
+- Skips resources that already exist with matching content.
+- Stops on existing tables or rows with different content. Updates to existing resources are intentionally out of scope.
+- Commits only when `--commit` is passed.
+
+Useful options:
+
+```bash
+# Plan without writing
+revisium example bootstrap --config ./bootstrap.config.json --url revisium://localhost:9222/admin/dictionary/master --dry-run
+
+# JSON summary for CI
+revisium example bootstrap --config ./bootstrap.config.json --url revisium://localhost:9222/admin/dictionary/master --json
+
+# Override configured endpoints for one run
+revisium example bootstrap \
+  --config ./bootstrap.config.json \
+  --url revisium://localhost:9222/admin/dictionary/master \
+  --endpoint REST_API \
+  --endpoint GRAPHQL
+```
+
+When `--endpoint` is provided at least once, the repeated flags replace the `endpoints` array from the config for that run.

--- a/e2e/tests/08-bootstrap.e2e-spec.ts
+++ b/e2e/tests/08-bootstrap.e2e-spec.ts
@@ -1,0 +1,160 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { buildUrl, runCli } from '../utils/cli-runner';
+import { deleteTestProject, generateProjectName } from '../utils/test-project';
+
+const CLEAR_REVISIUM_ENV = {
+  REVISIUM_URL: '',
+  REVISIUM_API_KEY: '',
+  REVISIUM_USERNAME: '',
+  REVISIUM_PASSWORD: '',
+};
+
+describe('Bootstrap commands', () => {
+  const createdProjects: string[] = [];
+  let workspaces: string[] = [];
+
+  afterEach(async () => {
+    for (const projectName of createdProjects) {
+      await deleteTestProject(projectName);
+    }
+    createdProjects.length = 0;
+
+    for (const workspace of workspaces) {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+    workspaces = [];
+  });
+
+  it('ensures projects, endpoints, and idempotent example bootstrap resources', async () => {
+    const workspace = createWorkspace();
+    const projectName = generateProjectName('e2e-bootstrap');
+    createdProjects.push(projectName);
+
+    const token = process.env.E2E_ADMIN_TOKEN!;
+    const targetUrl = buildUrl(projectName);
+    const env = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_TOKEN: token,
+    };
+
+    const projectEnsure = await runCli(
+      ['project', 'ensure', '--url', targetUrl],
+      { cwd: workspace, env },
+    );
+
+    expect(projectEnsure.exitCode).toBe(0);
+    expect(projectEnsure.stdout).toContain('Created project');
+
+    const endpointEnsure = await runCli(
+      ['endpoint', 'ensure', '--url', targetUrl, '--type', 'REST_API'],
+      { cwd: workspace, env },
+    );
+
+    expect(endpointEnsure.exitCode).toBe(0);
+    expect(endpointEnsure.stdout).toContain('REST_API');
+
+    const configPath = path.join(workspace, 'bootstrap.config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          projectName,
+          branchName: 'master',
+          endpoints: ['GRAPHQL'],
+          tables: [
+            {
+              id: 'FaqCategory',
+              schema: {
+                type: 'object',
+                required: ['name'],
+                properties: { name: { type: 'string', default: '' } },
+                additionalProperties: false,
+              },
+            },
+          ],
+          rows: [
+            {
+              tableId: 'FaqCategory',
+              rowId: 'billing',
+              data: { name: 'Billing' },
+            },
+          ],
+          commitMessage: 'Bootstrap dictionary example',
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+
+    const firstBootstrap = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        targetUrl,
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 90000 },
+    );
+
+    expect(firstBootstrap.exitCode).toBe(0);
+    const firstSummary = JSON.parse(firstBootstrap.stdout) as {
+      tables: { created: string[] };
+      rows: { created: string[] };
+      endpoints: { created: string[] };
+    };
+    expect(firstSummary.tables.created).toEqual(['FaqCategory']);
+    expect(firstSummary.rows.created).toEqual(['FaqCategory/billing']);
+    expect(firstSummary.endpoints.created).toEqual(['GRAPHQL']);
+
+    const secondBootstrap = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        targetUrl,
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 90000 },
+    );
+
+    expect(secondBootstrap.exitCode).toBe(0);
+    const secondSummary = JSON.parse(secondBootstrap.stdout) as {
+      tables: { created: string[]; skipped: string[] };
+      rows: { created: string[]; skipped: string[] };
+      endpoints: { created: string[]; skipped: string[] };
+    };
+    expect(secondSummary.tables.created).toEqual([]);
+    expect(secondSummary.tables.skipped).toEqual(['FaqCategory']);
+    expect(secondSummary.rows.created).toEqual([]);
+    expect(secondSummary.rows.skipped).toEqual(['FaqCategory/billing']);
+    expect(secondSummary.endpoints.created).toEqual([]);
+    expect(secondSummary.endpoints.skipped).toEqual(['GRAPHQL']);
+
+    const endpointList = await runCli(
+      ['endpoint', 'list', '--url', targetUrl, '--json'],
+      { cwd: workspace, env },
+    );
+
+    expect(endpointList.exitCode).toBe(0);
+    const listSummary = JSON.parse(endpointList.stdout) as {
+      endpoints: Array<{ type: string }>;
+    };
+    expect(
+      listSummary.endpoints.map((endpoint) => endpoint.type).sort(),
+    ).toEqual(['GRAPHQL', 'REST_API']);
+  }, 120000);
+
+  function createWorkspace(): string {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-bootstrap-'));
+    workspaces.push(workspace);
+    return workspace;
+  }
+});

--- a/e2e/tests/08-bootstrap.e2e-spec.ts
+++ b/e2e/tests/08-bootstrap.e2e-spec.ts
@@ -152,6 +152,150 @@ describe('Bootstrap commands', () => {
     ).toEqual(['GRAPHQL', 'REST_API']);
   }, 120000);
 
+  it('keeps project and endpoint ensure idempotent on re-run', async () => {
+    const workspace = createWorkspace();
+    const projectName = generateProjectName('e2e-bootstrap-idem');
+    createdProjects.push(projectName);
+
+    const env = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_TOKEN: process.env.E2E_ADMIN_TOKEN!,
+    };
+    const targetUrl = buildUrl(projectName);
+
+    const firstProject = await runCli(
+      ['project', 'ensure', '--url', targetUrl],
+      { cwd: workspace, env },
+    );
+    expect(firstProject.exitCode).toBe(0);
+    expect(firstProject.stdout).toContain('Created project');
+
+    const secondProject = await runCli(
+      ['project', 'ensure', '--url', targetUrl],
+      { cwd: workspace, env },
+    );
+    expect(secondProject.exitCode).toBe(0);
+    expect(secondProject.stdout).toContain('Project exists');
+
+    const firstEndpoint = await runCli(
+      ['endpoint', 'ensure', '--url', targetUrl, '--type', 'GRAPHQL'],
+      { cwd: workspace, env },
+    );
+    expect(firstEndpoint.exitCode).toBe(0);
+    expect(firstEndpoint.stdout).toContain('Created endpoint');
+
+    const secondEndpoint = await runCli(
+      ['endpoint', 'ensure', '--url', targetUrl, '--type', 'GRAPHQL'],
+      { cwd: workspace, env },
+    );
+    expect(secondEndpoint.exitCode).toBe(0);
+    expect(secondEndpoint.stdout).toContain('Found endpoint');
+  }, 120000);
+
+  it('plans changes in dry-run without creating resources', async () => {
+    const workspace = createWorkspace();
+    const projectName = generateProjectName('e2e-bootstrap-dry');
+    createdProjects.push(projectName);
+
+    const env = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_TOKEN: process.env.E2E_ADMIN_TOKEN!,
+    };
+    const targetUrl = buildUrl(projectName);
+
+    const dryRun = await runCli(
+      ['project', 'ensure', '--url', targetUrl, '--dry-run', '--json'],
+      { cwd: workspace, env },
+    );
+    expect(dryRun.exitCode).toBe(0);
+    const dryRunSummary = JSON.parse(dryRun.stdout) as {
+      projectStatus: string;
+      branchStatus: string;
+      dryRun: boolean;
+    };
+    expect(dryRunSummary).toMatchObject({
+      projectStatus: 'created',
+      branchStatus: 'created',
+      dryRun: true,
+    });
+
+    // Project should still not exist after a dry run.
+    const reRun = await runCli(
+      ['project', 'ensure', '--url', targetUrl, '--json'],
+      { cwd: workspace, env },
+    );
+    expect(reRun.exitCode).toBe(0);
+    const reRunSummary = JSON.parse(reRun.stdout) as {
+      projectStatus: string;
+    };
+    expect(reRunSummary.projectStatus).toBe('created');
+  }, 120000);
+
+  it('respects --endpoint overrides and --commit during example bootstrap', async () => {
+    const workspace = createWorkspace();
+    const projectName = generateProjectName('e2e-bootstrap-commit');
+    createdProjects.push(projectName);
+
+    const env = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_TOKEN: process.env.E2E_ADMIN_TOKEN!,
+    };
+    const targetUrl = buildUrl(projectName);
+    const configPath = path.join(workspace, 'bootstrap.config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          projectName,
+          branchName: 'master',
+          endpoints: ['GRAPHQL'],
+          tables: [
+            {
+              id: 'Tag',
+              schema: {
+                type: 'object',
+                required: ['label'],
+                properties: { label: { type: 'string', default: '' } },
+                additionalProperties: false,
+              },
+            },
+          ],
+          rows: [{ tableId: 'Tag', rowId: 'one', data: { label: 'One' } }],
+          commitMessage: 'Bootstrap with overrides',
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        targetUrl,
+        '--endpoint',
+        'REST_API',
+        '--commit',
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 120000 },
+    );
+
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as {
+      endpoints: { created: string[]; skipped: string[] };
+      commit: { status: string; revisionId?: string };
+    };
+    expect(summary.endpoints.created).toEqual(['REST_API']);
+    expect(summary.endpoints.skipped).toEqual([]);
+    expect(summary.commit.status).toBe('created');
+    expect(summary.commit.revisionId).toBeTruthy();
+  }, 180000);
+
   function createWorkspace(): string {
     const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-bootstrap-'));
     workspaces.push(workspace);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,12 +12,19 @@ import { ContextRemoveCommand } from 'src/commands/context/context-remove.comman
 import { ContextShowCommand } from 'src/commands/context/context-show.command';
 import { ContextUseCommand } from 'src/commands/context/context-use.command';
 import { CreateMigrationsCommand } from 'src/commands/schema/create-migrations.command';
+import { EndpointCommand } from 'src/commands/endpoint/endpoint.command';
+import { EndpointEnsureCommand } from 'src/commands/endpoint/endpoint-ensure.command';
+import { EndpointListCommand } from 'src/commands/endpoint/endpoint-list.command';
+import { ExampleBootstrapCommand } from 'src/commands/example/example-bootstrap.command';
+import { ExampleCommand } from 'src/commands/example/example.command';
 import { InstanceAddCommand } from 'src/commands/instance/instance-add.command';
 import { InstanceCommand } from 'src/commands/instance/instance.command';
 import { InstanceListCommand } from 'src/commands/instance/instance-list.command';
 import { InstanceRemoveCommand } from 'src/commands/instance/instance-remove.command';
 import { InstanceShowCommand } from 'src/commands/instance/instance-show.command';
 import { MigrationCommand } from 'src/commands/migration/migration.command';
+import { ProjectCommand } from 'src/commands/project/project.command';
+import { ProjectEnsureCommand } from 'src/commands/project/project-ensure.command';
 import { RowsCommand } from 'src/commands/rows/rows.command';
 import { SaveMigrationsCommand } from 'src/commands/migration/save-migrations.command';
 import { SaveRowsCommand } from 'src/commands/rows/save-rows.command';
@@ -60,6 +67,7 @@ import {
   CredentialStoreService,
   CredentialTargetService,
 } from 'src/services/credentials';
+import { BootstrapService } from 'src/services/bootstrap';
 
 @Module({
   imports: [
@@ -88,6 +96,13 @@ import {
     ContextShowCommand,
     ContextUseCommand,
     ContextRemoveCommand,
+    ProjectCommand,
+    ProjectEnsureCommand,
+    EndpointCommand,
+    EndpointEnsureCommand,
+    EndpointListCommand,
+    ExampleCommand,
+    ExampleBootstrapCommand,
     SchemaCommand,
     SaveSchemaCommand,
     CreateMigrationsCommand,
@@ -116,6 +131,7 @@ import {
     WorkspaceConfigService,
     CredentialStoreService,
     CredentialTargetService,
+    BootstrapService,
   ],
 })
 export class AppModule {}

--- a/src/commands/endpoint/__tests__/endpoint-ensure.command.spec.ts
+++ b/src/commands/endpoint/__tests__/endpoint-ensure.command.spec.ts
@@ -1,0 +1,129 @@
+import { EndpointEnsureCommand } from '../endpoint-ensure.command';
+import { BootstrapService } from 'src/services/bootstrap';
+import { LoggerService } from 'src/services/common';
+
+describe('EndpointEnsureCommand', () => {
+  let bootstrapService: {
+    ensureEndpoint: jest.Mock;
+    resolveTarget: jest.Mock;
+    formatEndpointHint: jest.Mock;
+    parseEndpointType: jest.Mock;
+  };
+  let logger: { info: jest.Mock; success: jest.Mock };
+  let command: EndpointEnsureCommand;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    bootstrapService = {
+      ensureEndpoint: jest.fn().mockResolvedValue({
+        endpoint: { id: 'rest-id', type: 'REST_API' },
+        status: 'created',
+        revision: 'draft',
+        dryRun: false,
+      }),
+      resolveTarget: jest.fn().mockResolvedValue({
+        baseUrl: 'http://localhost:9222',
+        organization: 'admin',
+        project: 'dictionary',
+        branch: 'master',
+        revision: 'draft',
+      }),
+      formatEndpointHint: jest
+        .fn()
+        .mockReturnValue('http://localhost:9222/endpoint/rest/admin/x/y/draft'),
+      parseEndpointType: jest.fn().mockReturnValue('REST_API'),
+    };
+    logger = { info: jest.fn(), success: jest.fn() };
+    command = new EndpointEnsureCommand(
+      bootstrapService as unknown as BootstrapService,
+      logger as unknown as LoggerService,
+    );
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('rejects when --type is missing', async () => {
+    await expect(command.run([], { type: undefined as never })).rejects.toThrow(
+      '--type option is required',
+    );
+  });
+
+  it('logs created endpoint info with hint', async () => {
+    await command.run([], { type: 'REST_API' });
+
+    expect(bootstrapService.ensureEndpoint).toHaveBeenCalledWith(
+      { type: 'REST_API' },
+      'REST_API',
+      undefined,
+    );
+    expect(logger.success).toHaveBeenCalledWith(
+      'Created endpoint rest-id (REST_API)',
+    );
+    expect(logger.info).toHaveBeenCalledWith('Revision: draft');
+    expect(logger.info).toHaveBeenCalledWith(
+      'Hint: http://localhost:9222/endpoint/rest/admin/x/y/draft',
+    );
+  });
+
+  it('shows "Found" when endpoint already exists', async () => {
+    bootstrapService.ensureEndpoint.mockResolvedValue({
+      endpoint: { id: 'rest-id', type: 'REST_API' },
+      status: 'skipped',
+      revision: 'draft',
+      dryRun: false,
+    });
+
+    await command.run([], { type: 'REST_API' });
+
+    expect(logger.success).toHaveBeenCalledWith(
+      'Found endpoint rest-id (REST_API)',
+    );
+  });
+
+  it('uses <dry-run> placeholder when no endpoint id is returned', async () => {
+    bootstrapService.ensureEndpoint.mockResolvedValue({
+      endpoint: { type: 'GRAPHQL' },
+      status: 'created',
+      revision: 'draft',
+      dryRun: true,
+    });
+
+    await command.run([], { type: 'GRAPHQL', dryRun: true });
+
+    expect(logger.success).toHaveBeenCalledWith(
+      'Created endpoint <dry-run> (GRAPHQL)',
+    );
+  });
+
+  it('emits JSON when --json is set', async () => {
+    await command.run([], { type: 'REST_API', json: true });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const firstCall = logSpy.mock.calls[0] as unknown[];
+    const payload = JSON.parse(firstCall[0] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toEqual({
+      endpoint: { id: 'rest-id', type: 'REST_API' },
+      status: 'created',
+      revision: 'draft',
+      dryRun: false,
+      hint: 'http://localhost:9222/endpoint/rest/admin/x/y/draft',
+    });
+    expect(logger.success).not.toHaveBeenCalled();
+  });
+
+  it('delegates option parsing to BootstrapService.parseEndpointType', () => {
+    expect(command.parseType('REST_API')).toBe('REST_API');
+    expect(bootstrapService.parseEndpointType).toHaveBeenCalledWith('REST_API');
+  });
+
+  it('parses boolean flags', () => {
+    expect(command.parseDryRun('true')).toBe(true);
+    expect(command.parseJson()).toBe(true);
+  });
+});

--- a/src/commands/endpoint/__tests__/endpoint-list.command.spec.ts
+++ b/src/commands/endpoint/__tests__/endpoint-list.command.spec.ts
@@ -1,0 +1,59 @@
+import { EndpointListCommand } from '../endpoint-list.command';
+import { BootstrapService } from 'src/services/bootstrap';
+import { LoggerService } from 'src/services/common';
+
+describe('EndpointListCommand', () => {
+  let bootstrapService: { listEndpoints: jest.Mock };
+  let logger: { info: jest.Mock };
+  let command: EndpointListCommand;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    bootstrapService = { listEndpoints: jest.fn() };
+    logger = { info: jest.fn() };
+    command = new EndpointListCommand(
+      bootstrapService as unknown as BootstrapService,
+      logger as unknown as LoggerService,
+    );
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('logs each endpoint id and type', async () => {
+    bootstrapService.listEndpoints.mockResolvedValue([
+      { id: 'rest', type: 'REST_API' },
+      { id: 'graphql', type: 'GRAPHQL' },
+    ]);
+
+    await command.run([], {});
+
+    expect(logger.info).toHaveBeenCalledWith('rest\tREST_API');
+    expect(logger.info).toHaveBeenCalledWith('graphql\tGRAPHQL');
+  });
+
+  it('reports when no endpoints exist', async () => {
+    bootstrapService.listEndpoints.mockResolvedValue([]);
+
+    await command.run([], {});
+
+    expect(logger.info).toHaveBeenCalledWith('No generated endpoints found');
+  });
+
+  it('emits JSON when --json is set', async () => {
+    const endpoints = [{ id: 'rest', type: 'REST_API' }];
+    bootstrapService.listEndpoints.mockResolvedValue(endpoints);
+
+    await command.run([], { json: true });
+
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ endpoints }, null, 2));
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('parses --json flag', () => {
+    expect(command.parseJson('true')).toBe(true);
+    expect(command.parseJson()).toBe(true);
+  });
+});

--- a/src/commands/endpoint/__tests__/endpoint.command.spec.ts
+++ b/src/commands/endpoint/__tests__/endpoint.command.spec.ts
@@ -1,0 +1,14 @@
+import { EndpointCommand } from '../endpoint.command';
+
+describe('EndpointCommand', () => {
+  it('shows help when no endpoint subcommand is provided', async () => {
+    const command = new EndpointCommand();
+    const help = jest.fn();
+
+    Object.assign(command, { command: { help } });
+
+    await command.run();
+
+    expect(help).toHaveBeenCalled();
+  });
+});

--- a/src/commands/endpoint/endpoint-ensure.command.ts
+++ b/src/commands/endpoint/endpoint-ensure.command.ts
@@ -1,0 +1,74 @@
+import { Option, SubCommand } from 'nest-commander';
+import { BaseCommand, BaseOptions } from 'src/commands/base.command';
+import { BootstrapService, EndpointType } from 'src/services/bootstrap';
+import { LoggerService } from 'src/services/common';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+
+type Options = BaseOptions & {
+  type: EndpointType;
+  dryRun?: boolean;
+  json?: boolean;
+};
+
+@SubCommand({
+  name: 'ensure',
+  description: 'Ensure a generated endpoint exists on the selected revision',
+})
+export class EndpointEnsureCommand extends BaseCommand {
+  constructor(
+    private readonly bootstrapService: BootstrapService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(_inputs: string[], options: Options): Promise<void> {
+    if (!options.type) {
+      throw new Error('Error: --type option is required');
+    }
+
+    const result = await this.bootstrapService.ensureEndpoint(
+      options,
+      options.type,
+      options.dryRun,
+    );
+    const target = await this.bootstrapService.resolveTarget(options);
+    const endpointId = result.endpoint.id || '<dry-run>';
+    const action = result.status === 'created' ? 'Created' : 'Found';
+    const hint = this.bootstrapService.formatEndpointHint(target, options.type);
+
+    if (options.json) {
+      console.log(JSON.stringify({ ...result, hint }, null, 2));
+      return;
+    }
+
+    this.logger.success(`${action} endpoint ${endpointId} (${options.type})`);
+    this.logger.info(`Revision: ${result.revision}`);
+    this.logger.info(`Hint: ${hint}`);
+  }
+
+  @Option({
+    flags: '--type <type>',
+    description: 'Endpoint type: REST_API or GRAPHQL',
+    required: true,
+  })
+  parseType(value: string): EndpointType {
+    return this.bootstrapService.parseEndpointType(value);
+  }
+
+  @Option({
+    flags: '--dry-run [boolean]',
+    description: 'Plan changes without writing',
+  })
+  parseDryRun(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+
+  @Option({
+    flags: '--json [boolean]',
+    description: 'Print machine-readable JSON',
+  })
+  parseJson(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+}

--- a/src/commands/endpoint/endpoint-list.command.ts
+++ b/src/commands/endpoint/endpoint-list.command.ts
@@ -1,0 +1,48 @@
+import { Option, SubCommand } from 'nest-commander';
+import { BaseCommand, BaseOptions } from 'src/commands/base.command';
+import { BootstrapService } from 'src/services/bootstrap';
+import { LoggerService } from 'src/services/common';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+
+type Options = BaseOptions & {
+  json?: boolean;
+};
+
+@SubCommand({
+  name: 'list',
+  description: 'List generated endpoints on the selected revision',
+})
+export class EndpointListCommand extends BaseCommand {
+  constructor(
+    private readonly bootstrapService: BootstrapService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(_inputs: string[], options: Options): Promise<void> {
+    const endpoints = await this.bootstrapService.listEndpoints(options);
+
+    if (options.json) {
+      console.log(JSON.stringify({ endpoints }, null, 2));
+      return;
+    }
+
+    if (endpoints.length === 0) {
+      this.logger.info('No generated endpoints found');
+      return;
+    }
+
+    for (const endpoint of endpoints) {
+      this.logger.info(`${endpoint.id}\t${endpoint.type}`);
+    }
+  }
+
+  @Option({
+    flags: '--json [boolean]',
+    description: 'Print machine-readable JSON',
+  })
+  parseJson(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+}

--- a/src/commands/endpoint/endpoint.command.ts
+++ b/src/commands/endpoint/endpoint.command.ts
@@ -1,0 +1,19 @@
+import { Command, CommandRunner } from 'nest-commander';
+import { EndpointEnsureCommand } from './endpoint-ensure.command';
+import { EndpointListCommand } from './endpoint-list.command';
+
+@Command({
+  name: 'endpoint',
+  description: 'Manage generated Revisium endpoints',
+  subCommands: [EndpointEnsureCommand, EndpointListCommand],
+})
+export class EndpointCommand extends CommandRunner {
+  constructor() {
+    super();
+  }
+
+  run(): Promise<void> {
+    this.command.help();
+    return Promise.resolve();
+  }
+}

--- a/src/commands/example/__tests__/example-bootstrap.command.spec.ts
+++ b/src/commands/example/__tests__/example-bootstrap.command.spec.ts
@@ -1,0 +1,146 @@
+import { ExampleBootstrapCommand } from '../example-bootstrap.command';
+import {
+  BootstrapService,
+  ExampleBootstrapSummary,
+} from 'src/services/bootstrap';
+import { LoggerService } from 'src/services/common';
+
+describe('ExampleBootstrapCommand', () => {
+  let bootstrapService: {
+    bootstrapExample: jest.Mock;
+    parseEndpointType: jest.Mock;
+  };
+  let logger: { info: jest.Mock; success: jest.Mock; summary: jest.Mock };
+  let command: ExampleBootstrapCommand;
+  let logSpy: jest.SpyInstance;
+  let summary: ExampleBootstrapSummary;
+
+  beforeEach(() => {
+    summary = {
+      dryRun: false,
+      target: {
+        organization: 'admin',
+        project: 'dictionary',
+        branch: 'master',
+        revision: 'draft',
+      },
+      project: {
+        organization: 'admin',
+        project: 'dictionary',
+        branch: 'master',
+        projectStatus: 'created',
+        branchStatus: 'created',
+        dryRun: false,
+      },
+      tables: { created: ['Faq'], skipped: [], conflicts: [] },
+      rows: { created: [], skipped: ['x/y'], conflicts: [] },
+      endpoints: { created: ['REST_API'], skipped: [], conflicts: [] },
+      commit: { status: 'created', revisionId: 'rev-1' },
+    };
+    bootstrapService = {
+      bootstrapExample: jest.fn().mockResolvedValue(summary),
+      parseEndpointType: jest.fn((value: string) => value),
+    };
+    logger = {
+      info: jest.fn(),
+      success: jest.fn(),
+      summary: jest.fn(),
+    };
+    command = new ExampleBootstrapCommand(
+      bootstrapService as unknown as BootstrapService,
+      logger as unknown as LoggerService,
+    );
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('rejects when --config is missing', async () => {
+    await expect(
+      command.run([], { config: undefined as never }),
+    ).rejects.toThrow('--config option is required');
+  });
+
+  it('forwards options to BootstrapService.bootstrapExample', async () => {
+    await command.run([], {
+      config: './bootstrap.json',
+      url: 'revisium://local',
+      context: 'ctx',
+      commit: true,
+      dryRun: false,
+      endpoint: ['REST_API'],
+    });
+
+    expect(bootstrapService.bootstrapExample).toHaveBeenCalledWith({
+      url: 'revisium://local',
+      context: 'ctx',
+      configPath: './bootstrap.json',
+      commit: true,
+      dryRun: false,
+      endpointOverrides: ['REST_API'],
+    });
+  });
+
+  it('prints a human-readable summary by default', async () => {
+    await command.run([], { config: './bootstrap.json' });
+
+    expect(logger.summary).toHaveBeenCalledWith(
+      'Bootstrap admin/dictionary/master:draft',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Project: created, branch: created',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Tables: created 1, skipped 0, conflicts 0',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Rows: created 0, skipped 1, conflicts 0',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Endpoints: created 1, skipped 0, conflicts 0',
+    );
+    expect(logger.info).toHaveBeenCalledWith('Commit: created');
+    expect(logger.info).toHaveBeenCalledWith('Revision: rev-1');
+  });
+
+  it('prefixes the summary with "Dry run: " when dry-run', async () => {
+    summary.dryRun = true;
+    summary.commit = { status: 'dry-run', message: 'm' };
+    delete (summary.commit as { revisionId?: string }).revisionId;
+
+    await command.run([], { config: './bootstrap.json' });
+
+    expect(logger.summary).toHaveBeenCalledWith(
+      'Dry run: Bootstrap admin/dictionary/master:draft',
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('Revision:'),
+    );
+  });
+
+  it('emits JSON when --json is set', async () => {
+    await command.run([], { config: './bootstrap.json', json: true });
+
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(summary, null, 2));
+    expect(logger.summary).not.toHaveBeenCalled();
+  });
+
+  it('parses --endpoint repeatedly via BootstrapService.parseEndpointType', () => {
+    const first = command.parseEndpoint('REST_API');
+    expect(first).toEqual(['REST_API']);
+    const second = command.parseEndpoint('GRAPHQL', first);
+    expect(second).toEqual(['REST_API', 'GRAPHQL']);
+    expect(bootstrapService.parseEndpointType).toHaveBeenCalledTimes(2);
+  });
+
+  it('parses boolean and string flags', () => {
+    expect(command.parseConfig('./bootstrap.json')).toBe('./bootstrap.json');
+    expect(command.parseCommit('true')).toBe(true);
+    expect(command.parseCommit()).toBe(true);
+    expect(command.parseDryRun()).toBe(true);
+    expect(command.parseJson()).toBe(true);
+    expect(command.parseNoInput()).toBe(true);
+  });
+});

--- a/src/commands/example/__tests__/example-bootstrap.command.spec.ts
+++ b/src/commands/example/__tests__/example-bootstrap.command.spec.ts
@@ -141,6 +141,5 @@ describe('ExampleBootstrapCommand', () => {
     expect(command.parseCommit()).toBe(true);
     expect(command.parseDryRun()).toBe(true);
     expect(command.parseJson()).toBe(true);
-    expect(command.parseNoInput()).toBe(true);
   });
 });

--- a/src/commands/example/__tests__/example.command.spec.ts
+++ b/src/commands/example/__tests__/example.command.spec.ts
@@ -1,0 +1,14 @@
+import { ExampleCommand } from '../example.command';
+
+describe('ExampleCommand', () => {
+  it('shows help when no example subcommand is provided', async () => {
+    const command = new ExampleCommand();
+    const help = jest.fn();
+
+    Object.assign(command, { command: { help } });
+
+    await command.run();
+
+    expect(help).toHaveBeenCalled();
+  });
+});

--- a/src/commands/example/example-bootstrap.command.ts
+++ b/src/commands/example/example-bootstrap.command.ts
@@ -1,0 +1,131 @@
+import { Option, SubCommand } from 'nest-commander';
+import { BaseCommand, BaseOptions } from 'src/commands/base.command';
+import {
+  BootstrapResourceSummary,
+  BootstrapService,
+  EndpointType,
+  ExampleBootstrapSummary,
+} from 'src/services/bootstrap';
+import { LoggerService } from 'src/services/common';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+
+type Options = BaseOptions & {
+  config: string;
+  commit?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+  noInput?: boolean;
+  endpoint?: EndpointType[];
+};
+
+@SubCommand({
+  name: 'bootstrap',
+  description: 'Bootstrap an example project from a config file',
+})
+export class ExampleBootstrapCommand extends BaseCommand {
+  constructor(
+    private readonly bootstrapService: BootstrapService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(_inputs: string[], options: Options): Promise<void> {
+    if (!options.config) {
+      throw new Error('Error: --config option is required');
+    }
+
+    const summary = await this.bootstrapService.bootstrapExample({
+      url: options.url,
+      context: options.context,
+      configPath: options.config,
+      commit: options.commit,
+      dryRun: options.dryRun,
+      endpointOverrides: options.endpoint,
+    });
+
+    if (options.json) {
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    this.printSummary(summary);
+  }
+
+  private printSummary(summary: ExampleBootstrapSummary): void {
+    const mode = summary.dryRun ? 'Dry run: ' : '';
+    this.logger.summary(
+      `${mode}Bootstrap ${summary.target.organization}/${summary.target.project}/${summary.target.branch}:${summary.target.revision}`,
+    );
+    this.logger.info(
+      `Project: ${summary.project.projectStatus}, branch: ${summary.project.branchStatus}`,
+    );
+    this.logger.info(this.formatSummary('Tables', summary.tables));
+    this.logger.info(this.formatSummary('Rows', summary.rows));
+    this.logger.info(this.formatSummary('Endpoints', summary.endpoints));
+    this.logger.info(`Commit: ${summary.commit.status}`);
+    if (summary.commit.revisionId) {
+      this.logger.info(`Revision: ${summary.commit.revisionId}`);
+    }
+  }
+
+  private formatSummary<T extends string>(
+    label: string,
+    summary: BootstrapResourceSummary<T>,
+  ): string {
+    return `${label}: created ${summary.created.length}, skipped ${summary.skipped.length}, conflicts ${summary.conflicts.length}`;
+  }
+
+  @Option({
+    flags: '--config <path>',
+    description: 'Bootstrap config JSON file',
+    required: true,
+  })
+  parseConfig(value: string): string {
+    return value;
+  }
+
+  @Option({
+    flags: '-c, --commit [boolean]',
+    description: 'Create a revision after bootstrap changes',
+  })
+  parseCommit(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+
+  @Option({
+    flags: '--dry-run [boolean]',
+    description: 'Plan changes without writing',
+  })
+  parseDryRun(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+
+  @Option({
+    flags: '--json [boolean]',
+    description: 'Print machine-readable JSON',
+  })
+  parseJson(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+
+  @Option({
+    flags: '--no-input [boolean]',
+    description: 'Disable interactive prompts',
+  })
+  parseNoInput(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+
+  @Option({
+    flags: '--endpoint <type>',
+    description:
+      'Endpoint type override. Repeat for multiple values. Replaces config endpoints when provided.',
+  })
+  parseEndpoint(value: string, previous?: EndpointType[]): EndpointType[] {
+    return [
+      ...(previous || []),
+      this.bootstrapService.parseEndpointType(value),
+    ];
+  }
+}

--- a/src/commands/example/example-bootstrap.command.ts
+++ b/src/commands/example/example-bootstrap.command.ts
@@ -14,7 +14,6 @@ type Options = BaseOptions & {
   commit?: boolean;
   dryRun?: boolean;
   json?: boolean;
-  noInput?: boolean;
   endpoint?: EndpointType[];
 };
 
@@ -106,14 +105,6 @@ export class ExampleBootstrapCommand extends BaseCommand {
     description: 'Print machine-readable JSON',
   })
   parseJson(value?: string): boolean {
-    return parseBooleanOption(value);
-  }
-
-  @Option({
-    flags: '--no-input [boolean]',
-    description: 'Disable interactive prompts',
-  })
-  parseNoInput(value?: string): boolean {
     return parseBooleanOption(value);
   }
 

--- a/src/commands/example/example.command.ts
+++ b/src/commands/example/example.command.ts
@@ -1,0 +1,18 @@
+import { Command, CommandRunner } from 'nest-commander';
+import { ExampleBootstrapCommand } from './example-bootstrap.command';
+
+@Command({
+  name: 'example',
+  description: 'Bootstrap Revisium example projects',
+  subCommands: [ExampleBootstrapCommand],
+})
+export class ExampleCommand extends CommandRunner {
+  constructor() {
+    super();
+  }
+
+  run(): Promise<void> {
+    this.command.help();
+    return Promise.resolve();
+  }
+}

--- a/src/commands/project/__tests__/project-ensure.command.spec.ts
+++ b/src/commands/project/__tests__/project-ensure.command.spec.ts
@@ -1,0 +1,119 @@
+import { ProjectEnsureCommand } from '../project-ensure.command';
+import { BootstrapService } from 'src/services/bootstrap';
+import { LoggerService } from 'src/services/common';
+
+describe('ProjectEnsureCommand', () => {
+  let bootstrapService: { ensureProject: jest.Mock };
+  let logger: { info: jest.Mock; success: jest.Mock };
+  let command: ProjectEnsureCommand;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    bootstrapService = {
+      ensureProject: jest.fn().mockResolvedValue({
+        organization: 'admin',
+        project: 'dictionary',
+        branch: 'master',
+        projectStatus: 'created',
+        branchStatus: 'created',
+        dryRun: false,
+      }),
+    };
+    logger = { info: jest.fn(), success: jest.fn() };
+    command = new ProjectEnsureCommand(
+      bootstrapService as unknown as BootstrapService,
+      logger as unknown as LoggerService,
+    );
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('logs success when a new project is created', async () => {
+    await command.run([], { url: 'revisium://local' });
+
+    expect(bootstrapService.ensureProject).toHaveBeenCalledWith(
+      { url: 'revisium://local' },
+      undefined,
+    );
+    expect(logger.success).toHaveBeenCalledWith(
+      'Created project "admin/dictionary" (created branch: master)',
+    );
+  });
+
+  it('logs an "exists" message when the project is skipped', async () => {
+    bootstrapService.ensureProject.mockResolvedValue({
+      organization: 'admin',
+      project: 'dictionary',
+      branch: 'master',
+      projectStatus: 'skipped',
+      branchStatus: 'skipped',
+      dryRun: false,
+    });
+
+    await command.run([], { context: 'cloud' });
+
+    expect(logger.success).toHaveBeenCalledWith(
+      'Project exists "admin/dictionary" (branch exists: master)',
+    );
+  });
+
+  it('prefixes the message with "Dry run: " when dry-run is set', async () => {
+    bootstrapService.ensureProject.mockResolvedValue({
+      organization: 'admin',
+      project: 'dictionary',
+      branch: 'master',
+      projectStatus: 'created',
+      branchStatus: 'skipped',
+      dryRun: true,
+    });
+
+    await command.run([], { dryRun: true });
+
+    expect(bootstrapService.ensureProject).toHaveBeenCalledWith(
+      { dryRun: true },
+      true,
+    );
+    expect(logger.success).toHaveBeenCalledWith(
+      'Dry run: Created project "admin/dictionary" (branch exists: master)',
+    );
+  });
+
+  it('emits JSON when --json is set', async () => {
+    bootstrapService.ensureProject.mockResolvedValue({
+      organization: 'admin',
+      project: 'dictionary',
+      branch: 'master',
+      projectStatus: 'skipped',
+      branchStatus: 'skipped',
+      dryRun: false,
+    });
+
+    await command.run([], { json: true });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          organization: 'admin',
+          project: 'dictionary',
+          branch: 'master',
+          projectStatus: 'skipped',
+          branchStatus: 'skipped',
+          dryRun: false,
+        },
+        null,
+        2,
+      ),
+    );
+    expect(logger.success).not.toHaveBeenCalled();
+  });
+
+  it('parses boolean options', () => {
+    expect(command.parseDryRun('true')).toBe(true);
+    expect(command.parseDryRun()).toBe(true);
+    expect(command.parseJson('false')).toBe(false);
+    expect(command.parseJson()).toBe(true);
+  });
+});

--- a/src/commands/project/__tests__/project.command.spec.ts
+++ b/src/commands/project/__tests__/project.command.spec.ts
@@ -1,0 +1,14 @@
+import { ProjectCommand } from '../project.command';
+
+describe('ProjectCommand', () => {
+  it('shows help when no project subcommand is provided', async () => {
+    const command = new ProjectCommand();
+    const help = jest.fn();
+
+    Object.assign(command, { command: { help } });
+
+    await command.run();
+
+    expect(help).toHaveBeenCalled();
+  });
+});

--- a/src/commands/project/project-ensure.command.ts
+++ b/src/commands/project/project-ensure.command.ts
@@ -1,0 +1,61 @@
+import { Option, SubCommand } from 'nest-commander';
+import { BaseCommand, BaseOptions } from 'src/commands/base.command';
+import { BootstrapService } from 'src/services/bootstrap';
+import { LoggerService } from 'src/services/common';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+
+type Options = BaseOptions & {
+  dryRun?: boolean;
+  json?: boolean;
+};
+
+@SubCommand({
+  name: 'ensure',
+  description: 'Ensure a Revisium project and branch exist',
+})
+export class ProjectEnsureCommand extends BaseCommand {
+  constructor(
+    private readonly bootstrapService: BootstrapService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(_inputs: string[], options: Options): Promise<void> {
+    const result = await this.bootstrapService.ensureProject(
+      options,
+      options.dryRun,
+    );
+
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    const projectMessage =
+      result.projectStatus === 'created' ? 'Created project' : 'Project exists';
+    const branchMessage =
+      result.branchStatus === 'created' ? 'created branch' : 'branch exists';
+    const mode = result.dryRun ? 'Dry run: ' : '';
+
+    this.logger.success(
+      `${mode}${projectMessage} "${result.organization}/${result.project}" (${branchMessage}: ${result.branch})`,
+    );
+  }
+
+  @Option({
+    flags: '--dry-run [boolean]',
+    description: 'Plan changes without writing',
+  })
+  parseDryRun(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+
+  @Option({
+    flags: '--json [boolean]',
+    description: 'Print machine-readable JSON',
+  })
+  parseJson(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+}

--- a/src/commands/project/project.command.ts
+++ b/src/commands/project/project.command.ts
@@ -1,0 +1,18 @@
+import { Command, CommandRunner } from 'nest-commander';
+import { ProjectEnsureCommand } from './project-ensure.command';
+
+@Command({
+  name: 'project',
+  description: 'Manage Revisium projects',
+  subCommands: [ProjectEnsureCommand],
+})
+export class ProjectCommand extends CommandRunner {
+  constructor() {
+    super();
+  }
+
+  run(): Promise<void> {
+    this.command.help();
+    return Promise.resolve();
+  }
+}

--- a/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
+++ b/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
@@ -1,0 +1,268 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { BootstrapService } from '../bootstrap.service';
+import { ConnectionService, RevisiumApiClient } from 'src/services/connection';
+
+jest.mock('src/services/connection', () => {
+  const actual: typeof import('src/services/connection') = jest.requireActual(
+    'src/services/connection',
+  );
+  return {
+    ...actual,
+    RevisiumApiClient: jest.fn(),
+  };
+});
+
+describe('BootstrapService', () => {
+  let service: BootstrapService;
+  let tempDir: string;
+  let connectionServiceFake: { resolveTarget: jest.Mock };
+  let apiClientFake: {
+    authenticate: jest.Mock;
+    client: {
+      org: jest.Mock;
+      branch: jest.Mock;
+      revision: jest.Mock;
+    };
+  };
+  let orgScopeFake: {
+    project: jest.Mock;
+    createProject: jest.Mock;
+  };
+  let projectScopeFake: {
+    get: jest.Mock;
+    branch: jest.Mock;
+    createBranch: jest.Mock;
+  };
+  let revisionScopeFake: {
+    getTableSchema: jest.Mock;
+    createTable: jest.Mock;
+    getRows: jest.Mock;
+    createRow: jest.Mock;
+    getEndpoints: jest.Mock;
+    createEndpoint: jest.Mock;
+    commit: jest.Mock;
+  };
+
+  const target = {
+    baseUrl: 'http://localhost:9222',
+    organization: 'admin',
+    project: 'dictionary',
+    branch: 'master',
+    revision: 'draft',
+    auth: { method: 'none' as const },
+  };
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'revisium-bootstrap-'));
+    connectionServiceFake = {
+      resolveTarget: jest.fn().mockResolvedValue(target),
+    };
+
+    revisionScopeFake = {
+      getTableSchema: jest.fn(),
+      createTable: jest
+        .fn()
+        .mockResolvedValue({ table: { id: 'FaqCategory' } }),
+      getRows: jest.fn(),
+      createRow: jest.fn().mockResolvedValue({ row: { id: 'billing' } }),
+      getEndpoints: jest.fn(),
+      createEndpoint: jest
+        .fn()
+        .mockImplementation((body: { type: string }) =>
+          Promise.resolve({ id: `endpoint-${body.type}`, type: body.type }),
+        ),
+      commit: jest.fn().mockResolvedValue({ id: 'revision-1' }),
+    };
+
+    projectScopeFake = {
+      get: jest.fn().mockResolvedValue({ name: 'dictionary' }),
+      branch: jest.fn().mockResolvedValue({ headRevisionId: 'head-1' }),
+      createBranch: jest.fn().mockResolvedValue({ name: 'master' }),
+    };
+
+    orgScopeFake = {
+      project: jest.fn().mockReturnValue(projectScopeFake),
+      createProject: jest.fn().mockResolvedValue({ name: 'dictionary' }),
+    };
+
+    apiClientFake = {
+      authenticate: jest.fn().mockResolvedValue('admin'),
+      client: {
+        org: jest.fn().mockReturnValue(orgScopeFake),
+        branch: jest.fn().mockResolvedValue({ name: 'master' }),
+        revision: jest.fn().mockResolvedValue(revisionScopeFake),
+      },
+    };
+
+    const MockApiClient = RevisiumApiClient as jest.MockedClass<
+      typeof RevisiumApiClient
+    >;
+    MockApiClient.mockImplementation(
+      () => apiClientFake as unknown as RevisiumApiClient,
+    );
+
+    service = new BootstrapService(
+      connectionServiceFake as unknown as ConnectionService,
+    );
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('creates a missing project with the target branch', async () => {
+    projectScopeFake.get.mockRejectedValue(new Error('Project not found'));
+
+    const result = await service.ensureProject({ url: 'revisium://local' });
+
+    expect(result.projectStatus).toBe('created');
+    expect(result.branchStatus).toBe('created');
+    expect(orgScopeFake.createProject).toHaveBeenCalledWith({
+      projectName: 'dictionary',
+      branchName: 'master',
+    });
+  });
+
+  it('creates a missing branch from the root branch head revision', async () => {
+    apiClientFake.client.branch.mockRejectedValue(
+      new Error('Branch not found'),
+    );
+
+    const result = await service.ensureProject({ url: 'revisium://local' });
+
+    expect(result.projectStatus).toBe('skipped');
+    expect(result.branchStatus).toBe('created');
+    expect(projectScopeFake.createBranch).toHaveBeenCalledWith(
+      'master',
+      'head-1',
+    );
+  });
+
+  it('reports only skipped resources when bootstrap config already matches', async () => {
+    const configPath = await writeBootstrapConfig({
+      endpoints: ['REST_API', 'GRAPHQL'],
+      tables: [tableConfig()],
+      rows: [rowConfig()],
+      commitMessage: 'Bootstrap dictionary example',
+    });
+    revisionScopeFake.getTableSchema.mockResolvedValue(tableConfig().schema);
+    revisionScopeFake.getRows.mockResolvedValue({
+      edges: [{ node: { id: 'billing', data: rowConfig().data } }],
+    });
+    revisionScopeFake.getEndpoints.mockResolvedValue([
+      { id: 'rest', type: 'REST_API' },
+      { id: 'graphql', type: 'GRAPHQL' },
+    ]);
+
+    const result = await service.bootstrapExample({
+      url: 'revisium://local',
+      configPath,
+      commit: true,
+    });
+
+    expect(result.tables.skipped).toEqual(['FaqCategory']);
+    expect(result.rows.skipped).toEqual(['FaqCategory/billing']);
+    expect(result.endpoints.skipped).toEqual(['REST_API', 'GRAPHQL']);
+    expect(result.commit.status).toBe('skipped');
+    expect(revisionScopeFake.createTable).not.toHaveBeenCalled();
+    expect(revisionScopeFake.createRow).not.toHaveBeenCalled();
+    expect(revisionScopeFake.createEndpoint).not.toHaveBeenCalled();
+    expect(revisionScopeFake.commit).not.toHaveBeenCalled();
+  });
+
+  it('creates missing resources and commits when requested', async () => {
+    const configPath = await writeBootstrapConfig({
+      endpoints: ['REST_API'],
+      tables: [tableConfig()],
+      rows: [rowConfig()],
+      commitMessage: 'Bootstrap dictionary example',
+    });
+    revisionScopeFake.getTableSchema.mockRejectedValue(
+      new Error('Table not found'),
+    );
+    revisionScopeFake.getRows.mockResolvedValue({ edges: [] });
+    revisionScopeFake.getEndpoints.mockResolvedValue([]);
+
+    const result = await service.bootstrapExample({
+      url: 'revisium://local',
+      configPath,
+      commit: true,
+    });
+
+    expect(result.tables.created).toEqual(['FaqCategory']);
+    expect(result.rows.created).toEqual(['FaqCategory/billing']);
+    expect(result.endpoints.created).toEqual(['REST_API']);
+    expect(result.commit).toEqual({
+      status: 'created',
+      revisionId: 'revision-1',
+      message: 'Bootstrap dictionary example',
+    });
+    expect(revisionScopeFake.createTable).toHaveBeenCalledWith(
+      'FaqCategory',
+      tableConfig().schema,
+    );
+    expect(revisionScopeFake.createRow).toHaveBeenCalledWith(
+      'FaqCategory',
+      'billing',
+      rowConfig().data,
+    );
+    expect(revisionScopeFake.createEndpoint).toHaveBeenCalledWith({
+      type: 'REST_API',
+    });
+  });
+
+  it('stops on schema conflicts without writing', async () => {
+    const configPath = await writeBootstrapConfig({
+      tables: [tableConfig()],
+      rows: [],
+    });
+    revisionScopeFake.getTableSchema.mockResolvedValue({
+      type: 'object',
+      properties: { name: { type: 'number' } },
+    });
+
+    await expect(
+      service.bootstrapExample({ url: 'revisium://local', configPath }),
+    ).rejects.toThrow('Bootstrap table conflict');
+
+    expect(revisionScopeFake.createTable).not.toHaveBeenCalled();
+    expect(revisionScopeFake.createRow).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid config shape', async () => {
+    const configPath = await writeBootstrapConfig({
+      tables: [{ id: 'FaqCategory' }],
+    });
+
+    await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+      'tables[0].schema must be an object',
+    );
+  });
+
+  async function writeBootstrapConfig(data: unknown): Promise<string> {
+    const configPath = join(tempDir, 'bootstrap.config.json');
+    await writeFile(configPath, JSON.stringify(data), 'utf-8');
+    return configPath;
+  }
+
+  function tableConfig() {
+    return {
+      id: 'FaqCategory',
+      schema: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+      },
+    };
+  }
+
+  function rowConfig() {
+    return {
+      tableId: 'FaqCategory',
+      rowId: 'billing',
+      data: { name: 'Billing' },
+    };
+  }
+});

--- a/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
+++ b/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
@@ -517,6 +517,80 @@ describe('BootstrapService', () => {
       expect(revisionScopeFake.commit).not.toHaveBeenCalled();
     });
 
+    it('diffs against root branch head when only the branch is missing in dry-run', async () => {
+      apiClientFake.client.branch.mockRejectedValue(
+        new Error('Branch not found'),
+      );
+      projectScopeFake.branch.mockResolvedValue({
+        branchName: 'master',
+        headRevisionId: 'root-head',
+      });
+      const rootHeadRevisionScope = {
+        getTableSchema: jest.fn().mockResolvedValue(tableConfig().schema),
+        getRows: jest.fn().mockResolvedValue({
+          edges: [{ node: { id: 'billing', data: rowConfig().data } }],
+        }),
+        getEndpoints: jest
+          .fn()
+          .mockResolvedValue([{ id: 'rest', type: 'REST_API' }]),
+        createTable: jest.fn(),
+        createRow: jest.fn(),
+        createEndpoint: jest.fn(),
+        commit: jest.fn(),
+      };
+      apiClientFake.client.revision
+        .mockReset()
+        .mockImplementation(({ revision }: { revision: string }) =>
+          Promise.resolve(
+            revision === 'root-head'
+              ? rootHeadRevisionScope
+              : revisionScopeFake,
+          ),
+        );
+
+      const configPath = await writeBootstrapConfig({
+        endpoints: ['REST_API'],
+        tables: [tableConfig()],
+        rows: [rowConfig()],
+      });
+
+      const result = await service.bootstrapExample({
+        url: 'revisium://local/admin/dictionary/feature',
+        configPath,
+        dryRun: true,
+      });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.project.branchStatus).toBe('created');
+      expect(result.tables.created).toEqual([]);
+      expect(result.tables.skipped).toEqual(['FaqCategory']);
+      expect(result.rows.created).toEqual([]);
+      expect(result.rows.skipped).toEqual(['FaqCategory/billing']);
+      expect(result.endpoints.created).toEqual([]);
+      expect(result.endpoints.skipped).toEqual(['REST_API']);
+      expect(rootHeadRevisionScope.createTable).not.toHaveBeenCalled();
+      expect(rootHeadRevisionScope.createRow).not.toHaveBeenCalled();
+      expect(projectScopeFake.createBranch).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-draft target before any project is created', async () => {
+      connectionServiceFake.resolveTarget.mockResolvedValue({
+        ...target,
+        revision: 'head',
+      });
+      const configPath = await writeBootstrapConfig({
+        tables: [tableConfig()],
+        rows: [],
+      });
+
+      await expect(
+        service.bootstrapExample({ url: 'revisium://local', configPath }),
+      ).rejects.toThrow('requires a draft revision');
+
+      expect(orgScopeFake.createProject).not.toHaveBeenCalled();
+      expect(projectScopeFake.createBranch).not.toHaveBeenCalled();
+    });
+
     it('reports dry-run commit when there are pending changes', async () => {
       const configPath = await writeBootstrapConfig({
         tables: [tableConfig()],

--- a/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
+++ b/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
@@ -242,6 +242,462 @@ describe('BootstrapService', () => {
     );
   });
 
+  describe('parseEndpointType', () => {
+    it('returns valid types', () => {
+      expect(service.parseEndpointType('REST_API')).toBe('REST_API');
+      expect(service.parseEndpointType('GRAPHQL')).toBe('GRAPHQL');
+    });
+
+    it('throws for unknown types', () => {
+      expect(() => service.parseEndpointType('UNKNOWN')).toThrow(
+        'Endpoint type must be REST_API or GRAPHQL',
+      );
+    });
+  });
+
+  describe('formatEndpointHint', () => {
+    it('returns the GraphQL endpoint URL', () => {
+      const hint = service.formatEndpointHint(
+        {
+          baseUrl: 'http://localhost:9222',
+          organization: 'admin',
+          project: 'dictionary',
+          branch: 'master',
+          revision: 'draft',
+          auth: { method: 'none' },
+        },
+        'GRAPHQL',
+      );
+      expect(hint).toBe(
+        'http://localhost:9222/endpoint/graphql/admin/dictionary/master/draft',
+      );
+    });
+
+    it('returns the REST endpoint URL with default branch and revision', () => {
+      const hint = service.formatEndpointHint(
+        {
+          baseUrl: 'http://localhost:9222',
+          organization: 'admin',
+          project: 'dictionary',
+          branch: '',
+          revision: '',
+          auth: { method: 'none' },
+        } as never,
+        'REST_API',
+      );
+      expect(hint).toBe(
+        'http://localhost:9222/endpoint/rest/admin/dictionary/master/draft',
+      );
+    });
+  });
+
+  describe('resolveTarget', () => {
+    it('delegates to ConnectionService', async () => {
+      const result = await service.resolveTarget({ url: 'revisium://local' });
+      expect(connectionServiceFake.resolveTarget).toHaveBeenCalledWith({
+        url: 'revisium://local',
+      });
+      expect(result).toBe(target);
+    });
+  });
+
+  describe('ensureProject dry-run', () => {
+    it('does not call createProject in dry-run mode when missing', async () => {
+      projectScopeFake.get.mockRejectedValue(new Error('Project not found'));
+
+      const result = await service.ensureProject(
+        { url: 'revisium://local' },
+        true,
+      );
+
+      expect(result).toMatchObject({
+        projectStatus: 'created',
+        branchStatus: 'created',
+        dryRun: true,
+      });
+      expect(orgScopeFake.createProject).not.toHaveBeenCalled();
+    });
+
+    it('does not call createBranch in dry-run when branch is missing', async () => {
+      apiClientFake.client.branch.mockRejectedValue(
+        new Error('Branch not found'),
+      );
+
+      const result = await service.ensureProject(
+        { url: 'revisium://local' },
+        true,
+      );
+
+      expect(result.branchStatus).toBe('created');
+      expect(projectScopeFake.createBranch).not.toHaveBeenCalled();
+      expect(projectScopeFake.branch).not.toHaveBeenCalled();
+    });
+
+    it('rethrows non-not-found errors from project lookup', async () => {
+      const error = Object.assign(new Error('boom'), { status: 500 });
+      projectScopeFake.get.mockRejectedValue(error);
+
+      await expect(
+        service.ensureProject({ url: 'revisium://local' }),
+      ).rejects.toThrow('boom');
+    });
+
+    it('rethrows non-not-found errors from branch lookup', async () => {
+      const error = Object.assign(new Error('boom'), { status: 500 });
+      apiClientFake.client.branch.mockRejectedValue(error);
+
+      await expect(
+        service.ensureProject({ url: 'revisium://local' }),
+      ).rejects.toThrow('boom');
+    });
+  });
+
+  describe('ensureEndpoint', () => {
+    it('skips when an endpoint of the requested type exists', async () => {
+      revisionScopeFake.getEndpoints.mockResolvedValue([
+        { id: 'rest-id', type: 'REST_API' },
+      ]);
+
+      const result = await service.ensureEndpoint(
+        { url: 'revisium://local' },
+        'REST_API',
+      );
+
+      expect(result.status).toBe('skipped');
+      expect(revisionScopeFake.createEndpoint).not.toHaveBeenCalled();
+    });
+
+    it('returns a synthetic endpoint in dry-run when missing', async () => {
+      revisionScopeFake.getEndpoints.mockResolvedValue([]);
+
+      const result = await service.ensureEndpoint(
+        { url: 'revisium://local' },
+        'GRAPHQL',
+        true,
+      );
+
+      expect(result.status).toBe('created');
+      expect(result.endpoint).toEqual({ type: 'GRAPHQL' });
+      expect(revisionScopeFake.createEndpoint).not.toHaveBeenCalled();
+    });
+
+    it('creates a missing endpoint when not in dry-run', async () => {
+      revisionScopeFake.getEndpoints.mockResolvedValue([]);
+
+      const result = await service.ensureEndpoint(
+        { url: 'revisium://local' },
+        'REST_API',
+      );
+
+      expect(result.status).toBe('created');
+      expect(revisionScopeFake.createEndpoint).toHaveBeenCalledWith({
+        type: 'REST_API',
+      });
+    });
+  });
+
+  describe('listEndpoints', () => {
+    it('returns endpoints from the resolved revision', async () => {
+      const endpoints = [{ id: 'rest', type: 'REST_API' }];
+      revisionScopeFake.getEndpoints.mockResolvedValue(endpoints);
+
+      const result = await service.listEndpoints({ url: 'revisium://local' });
+
+      expect(result).toBe(endpoints);
+    });
+  });
+
+  describe('bootstrapExample validation', () => {
+    it('rejects when target revision is not draft', async () => {
+      connectionServiceFake.resolveTarget.mockResolvedValue({
+        ...target,
+        revision: 'head',
+      });
+      const configPath = await writeBootstrapConfig({
+        tables: [tableConfig()],
+        rows: [],
+      });
+
+      await expect(
+        service.bootstrapExample({ url: 'revisium://local', configPath }),
+      ).rejects.toThrow('requires a draft revision');
+    });
+
+    it('rejects when projectName mismatches target', async () => {
+      const configPath = await writeBootstrapConfig({
+        projectName: 'different',
+        tables: [],
+        rows: [],
+      });
+
+      await expect(
+        service.bootstrapExample({ url: 'revisium://local', configPath }),
+      ).rejects.toThrow(
+        'Bootstrap config projectName "different" does not match target project "dictionary"',
+      );
+    });
+
+    it('rejects when branchName mismatches target', async () => {
+      const configPath = await writeBootstrapConfig({
+        branchName: 'other',
+        tables: [],
+        rows: [],
+      });
+
+      await expect(
+        service.bootstrapExample({ url: 'revisium://local', configPath }),
+      ).rejects.toThrow(
+        'Bootstrap config branchName "other" does not match target branch "master"',
+      );
+    });
+
+    it('reports row conflicts and stops without writing', async () => {
+      const configPath = await writeBootstrapConfig({
+        tables: [],
+        rows: [rowConfig()],
+      });
+      revisionScopeFake.getRows.mockResolvedValue({
+        edges: [{ node: { id: 'billing', data: { name: 'Different' } } }],
+      });
+
+      await expect(
+        service.bootstrapExample({ url: 'revisium://local', configPath }),
+      ).rejects.toThrow('Bootstrap row conflict');
+      expect(revisionScopeFake.createRow).not.toHaveBeenCalled();
+    });
+
+    it('honors endpoint overrides over config endpoints', async () => {
+      const configPath = await writeBootstrapConfig({
+        endpoints: ['REST_API'],
+        tables: [],
+        rows: [],
+      });
+      revisionScopeFake.getEndpoints.mockResolvedValue([]);
+
+      const result = await service.bootstrapExample({
+        url: 'revisium://local',
+        configPath,
+        endpointOverrides: ['GRAPHQL'],
+      });
+
+      expect(result.endpoints.created).toEqual(['GRAPHQL']);
+      expect(revisionScopeFake.createEndpoint).toHaveBeenCalledWith({
+        type: 'GRAPHQL',
+      });
+      expect(revisionScopeFake.createEndpoint).not.toHaveBeenCalledWith({
+        type: 'REST_API',
+      });
+    });
+
+    it('plans created resources without writing in dry-run when project is missing', async () => {
+      projectScopeFake.get.mockRejectedValue(new Error('Project not found'));
+      const configPath = await writeBootstrapConfig({
+        endpoints: ['REST_API'],
+        tables: [tableConfig()],
+        rows: [rowConfig()],
+        commitMessage: 'demo',
+      });
+
+      const result = await service.bootstrapExample({
+        url: 'revisium://local',
+        configPath,
+        commit: true,
+        dryRun: true,
+      });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.tables.created).toEqual(['FaqCategory']);
+      expect(result.rows.created).toEqual(['FaqCategory/billing']);
+      expect(result.endpoints.created).toEqual(['REST_API']);
+      expect(result.commit).toEqual({ status: 'dry-run', message: 'demo' });
+      expect(orgScopeFake.createProject).not.toHaveBeenCalled();
+      expect(revisionScopeFake.createTable).not.toHaveBeenCalled();
+      expect(revisionScopeFake.createRow).not.toHaveBeenCalled();
+      expect(revisionScopeFake.createEndpoint).not.toHaveBeenCalled();
+      expect(revisionScopeFake.commit).not.toHaveBeenCalled();
+    });
+
+    it('reports dry-run commit when there are pending changes', async () => {
+      const configPath = await writeBootstrapConfig({
+        tables: [tableConfig()],
+        rows: [],
+        commitMessage: 'demo',
+      });
+      revisionScopeFake.getTableSchema.mockRejectedValue(
+        new Error('Table not found'),
+      );
+
+      const result = await service.bootstrapExample({
+        url: 'revisium://local',
+        configPath,
+        commit: true,
+        dryRun: true,
+      });
+
+      expect(result.commit).toEqual({ status: 'dry-run', message: 'demo' });
+      expect(revisionScopeFake.commit).not.toHaveBeenCalled();
+    });
+
+    it('rethrows non-not-found errors from getTableSchema', async () => {
+      const configPath = await writeBootstrapConfig({
+        tables: [tableConfig()],
+        rows: [],
+      });
+      const error = Object.assign(new Error('server error'), { status: 500 });
+      revisionScopeFake.getTableSchema.mockRejectedValue(error);
+
+      await expect(
+        service.bootstrapExample({ url: 'revisium://local', configPath }),
+      ).rejects.toThrow('server error');
+    });
+
+    it('uses the default commit message when none is provided', async () => {
+      const configPath = await writeBootstrapConfig({
+        tables: [tableConfig()],
+        rows: [],
+      });
+      revisionScopeFake.getTableSchema.mockRejectedValue(
+        new Error('Table not found'),
+      );
+
+      const result = await service.bootstrapExample({
+        url: 'revisium://local',
+        configPath,
+        commit: true,
+      });
+
+      expect(result.commit).toEqual({
+        status: 'created',
+        revisionId: 'revision-1',
+        message: 'Bootstrap example via revisium-cli',
+      });
+    });
+  });
+
+  describe('loadBootstrapConfig validation', () => {
+    it('rejects non-JSON files', async () => {
+      const configPath = join(tempDir, 'broken.json');
+      await writeFile(configPath, 'not json', 'utf-8');
+
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'Could not read bootstrap config',
+      );
+    });
+
+    it('rejects when the JSON root is not an object', async () => {
+      const configPath = await writeBootstrapConfig([1, 2, 3]);
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'Bootstrap config must be a JSON object',
+      );
+    });
+
+    it('rejects when "endpoints" is not an array', async () => {
+      const configPath = await writeBootstrapConfig({ endpoints: 'REST_API' });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'field "endpoints" must be an array',
+      );
+    });
+
+    it('rejects non-string entries in "endpoints"', async () => {
+      const configPath = await writeBootstrapConfig({ endpoints: [42] });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        '"endpoints[0]" must be a string',
+      );
+    });
+
+    it('rejects when "tables" is not an array', async () => {
+      const configPath = await writeBootstrapConfig({ tables: {} });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'field "tables" must be an array',
+      );
+    });
+
+    it('rejects when a table is not an object', async () => {
+      const configPath = await writeBootstrapConfig({ tables: ['x'] });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'tables[0] must be an object',
+      );
+    });
+
+    it('rejects when a table id is missing or empty', async () => {
+      const configPath = await writeBootstrapConfig({
+        tables: [{ id: '', schema: {} }],
+      });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'tables[0].id must be a non-empty string',
+      );
+    });
+
+    it('rejects when "rows" is not an array', async () => {
+      const configPath = await writeBootstrapConfig({ rows: 'x' });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'field "rows" must be an array',
+      );
+    });
+
+    it('rejects when a row is not an object', async () => {
+      const configPath = await writeBootstrapConfig({ rows: [1] });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'rows[0] must be an object',
+      );
+    });
+
+    it('rejects when row.tableId is missing or empty', async () => {
+      const configPath = await writeBootstrapConfig({
+        rows: [{ tableId: '', rowId: 'r', data: {} }],
+      });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'rows[0].tableId must be a non-empty string',
+      );
+    });
+
+    it('rejects when row.rowId is missing or empty', async () => {
+      const configPath = await writeBootstrapConfig({
+        rows: [{ tableId: 't', rowId: '', data: {} }],
+      });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'rows[0].rowId must be a non-empty string',
+      );
+    });
+
+    it('rejects when row.data is not an object', async () => {
+      const configPath = await writeBootstrapConfig({
+        rows: [{ tableId: 't', rowId: 'r', data: 'x' }],
+      });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'rows[0].data must be an object',
+      );
+    });
+
+    it('rejects when an optional string field has the wrong type', async () => {
+      const configPath = await writeBootstrapConfig({
+        commitMessage: 42,
+      });
+      await expect(service.loadBootstrapConfig(configPath)).rejects.toThrow(
+        'field "commitMessage" must be a string',
+      );
+    });
+
+    it('parses a complete config and de-duplicates endpoint entries', async () => {
+      const configPath = await writeBootstrapConfig({
+        projectName: 'dictionary',
+        branchName: 'master',
+        endpoints: ['REST_API', 'REST_API', 'GRAPHQL'],
+        tables: [tableConfig()],
+        rows: [rowConfig()],
+        commitMessage: 'demo',
+      });
+
+      const parsed = await service.loadBootstrapConfig(configPath);
+      expect(parsed.projectName).toBe('dictionary');
+      expect(parsed.branchName).toBe('master');
+      expect(parsed.endpoints).toEqual(['REST_API', 'GRAPHQL']);
+      expect(parsed.tables).toHaveLength(1);
+      expect(parsed.rows).toHaveLength(1);
+      expect(parsed.commitMessage).toBe('demo');
+    });
+  });
+
   async function writeBootstrapConfig(data: unknown): Promise<string> {
     const configPath = join(tempDir, 'bootstrap.config.json');
     await writeFile(configPath, JSON.stringify(data), 'utf-8');

--- a/src/services/bootstrap/bootstrap.service.ts
+++ b/src/services/bootstrap/bootstrap.service.ts
@@ -1,0 +1,670 @@
+import { readFile } from 'node:fs/promises';
+import { isDeepStrictEqual } from 'node:util';
+import { Injectable } from '@nestjs/common';
+import { EndpointModel, RevisionScope, RowModel } from '@revisium/client';
+import { ConnectionService, RevisiumApiClient } from 'src/services/connection';
+import { RevisiumUrlComplete } from 'src/services/url';
+
+export type EndpointType = 'REST_API' | 'GRAPHQL';
+
+export interface TargetOptions {
+  url?: string;
+  context?: string;
+}
+
+export interface ProjectEnsureResult {
+  organization: string;
+  project: string;
+  branch: string;
+  projectStatus: 'created' | 'skipped';
+  branchStatus: 'created' | 'skipped';
+  dryRun: boolean;
+}
+
+export interface EndpointEnsureResult {
+  endpoint: EndpointModel | { id?: string; type: EndpointType };
+  status: 'created' | 'skipped';
+  revision: string;
+  dryRun: boolean;
+}
+
+export interface BootstrapConflict {
+  id: string;
+  reason: string;
+}
+
+export interface BootstrapResourceSummary<T = string> {
+  created: T[];
+  skipped: T[];
+  conflicts: BootstrapConflict[];
+}
+
+export interface BootstrapCommitSummary {
+  status: 'created' | 'skipped' | 'dry-run';
+  revisionId?: string;
+  message?: string;
+}
+
+export interface ExampleBootstrapSummary {
+  dryRun: boolean;
+  target: {
+    organization: string;
+    project: string;
+    branch: string;
+    revision: string;
+  };
+  project: ProjectEnsureResult;
+  tables: BootstrapResourceSummary;
+  rows: BootstrapResourceSummary;
+  endpoints: BootstrapResourceSummary<EndpointType>;
+  commit: BootstrapCommitSummary;
+}
+
+export interface ExampleBootstrapOptions extends TargetOptions {
+  configPath: string;
+  commit?: boolean;
+  dryRun?: boolean;
+  endpointOverrides?: EndpointType[];
+}
+
+interface ResolvedClient {
+  url: RevisiumUrlComplete;
+  apiClient: RevisiumApiClient;
+}
+
+interface BootstrapTableConfig {
+  id: string;
+  schema: object;
+}
+
+interface BootstrapRowConfig {
+  tableId: string;
+  rowId: string;
+  data: object;
+}
+
+interface ExampleBootstrapConfig {
+  projectName?: string;
+  branchName?: string;
+  endpoints: EndpointType[];
+  tables: BootstrapTableConfig[];
+  rows: BootstrapRowConfig[];
+  commitMessage?: string;
+}
+
+@Injectable()
+export class BootstrapService {
+  constructor(private readonly connectionService: ConnectionService) {}
+
+  async ensureProject(
+    options: TargetOptions,
+    dryRun = false,
+  ): Promise<ProjectEnsureResult> {
+    const { url, apiClient } = await this.createResolvedClient(options);
+    const branchName = url.branch || 'master';
+    const orgScope = apiClient.client.org(url.organization);
+    const projectScope = orgScope.project(url.project);
+
+    let projectStatus: ProjectEnsureResult['projectStatus'] = 'skipped';
+    let branchStatus: ProjectEnsureResult['branchStatus'] = 'skipped';
+
+    try {
+      await projectScope.get();
+    } catch (error) {
+      if (!this.isNotFoundError(error)) {
+        throw error;
+      }
+
+      projectStatus = 'created';
+      branchStatus = 'created';
+      if (!dryRun) {
+        await orgScope.createProject({
+          projectName: url.project,
+          branchName,
+        });
+      }
+
+      return {
+        organization: url.organization,
+        project: url.project,
+        branch: branchName,
+        projectStatus,
+        branchStatus,
+        dryRun,
+      };
+    }
+
+    try {
+      await apiClient.client.branch({
+        org: url.organization,
+        project: url.project,
+        branch: branchName,
+      });
+    } catch (error) {
+      if (!this.isNotFoundError(error)) {
+        throw error;
+      }
+
+      branchStatus = 'created';
+      if (!dryRun) {
+        const rootBranch = await projectScope.branch();
+        await projectScope.createBranch(branchName, rootBranch.headRevisionId);
+      }
+    }
+
+    return {
+      organization: url.organization,
+      project: url.project,
+      branch: branchName,
+      projectStatus,
+      branchStatus,
+      dryRun,
+    };
+  }
+
+  async ensureEndpoint(
+    options: TargetOptions,
+    type: EndpointType,
+    dryRun = false,
+  ): Promise<EndpointEnsureResult> {
+    const { url, apiClient } = await this.createResolvedClient(options);
+    const revisionScope = await this.resolveRevisionScope(url, apiClient);
+    const endpoint = await this.findEndpoint(revisionScope, type);
+
+    if (endpoint) {
+      return {
+        endpoint,
+        status: 'skipped',
+        revision: url.revision,
+        dryRun,
+      };
+    }
+
+    if (dryRun) {
+      return {
+        endpoint: { type },
+        status: 'created',
+        revision: url.revision,
+        dryRun,
+      };
+    }
+
+    return {
+      endpoint: await revisionScope.createEndpoint({ type }),
+      status: 'created',
+      revision: url.revision,
+      dryRun,
+    };
+  }
+
+  async listEndpoints(options: TargetOptions): Promise<EndpointModel[]> {
+    const { url, apiClient } = await this.createResolvedClient(options);
+    const revisionScope = await this.resolveRevisionScope(url, apiClient);
+    return revisionScope.getEndpoints();
+  }
+
+  async bootstrapExample(
+    options: ExampleBootstrapOptions,
+  ): Promise<ExampleBootstrapSummary> {
+    const config = await this.loadBootstrapConfig(options.configPath);
+    const { url, apiClient } = await this.createResolvedClient(options);
+    this.assertConfigMatchesTarget(config, url);
+
+    const dryRun = Boolean(options.dryRun);
+    const endpoints =
+      options.endpointOverrides && options.endpointOverrides.length > 0
+        ? this.uniqueEndpoints(options.endpointOverrides)
+        : config.endpoints;
+
+    const project = await this.ensureProject(options, dryRun);
+    const emptySummary = this.createEmptySummary(url, project, dryRun);
+
+    if (dryRun && this.projectWouldBeCreated(project)) {
+      emptySummary.tables.created = config.tables.map((table) => table.id);
+      emptySummary.rows.created = config.rows.map((row) =>
+        this.formatRowId(row.tableId, row.rowId),
+      );
+      emptySummary.endpoints.created = endpoints;
+      emptySummary.commit = this.buildSkippedCommitSummary(
+        options.commit,
+        config.commitMessage,
+        dryRun,
+        this.countCreated(emptySummary),
+      );
+      return emptySummary;
+    }
+
+    const revisionScope = await this.resolveRevisionScope(url, apiClient);
+    this.assertWritableRevision(url);
+
+    for (const table of config.tables) {
+      await this.ensureTable(revisionScope, table, emptySummary.tables, dryRun);
+      this.throwIfConflicts(emptySummary.tables, 'table');
+    }
+
+    for (const row of config.rows) {
+      await this.ensureRow(revisionScope, row, emptySummary.rows, dryRun);
+      this.throwIfConflicts(emptySummary.rows, 'row');
+    }
+
+    for (const endpointType of endpoints) {
+      await this.ensureEndpointOnRevision(
+        revisionScope,
+        endpointType,
+        emptySummary.endpoints,
+        dryRun,
+      );
+    }
+
+    emptySummary.commit = await this.commitIfRequested(
+      revisionScope,
+      options.commit,
+      config.commitMessage,
+      dryRun,
+      this.countCreated(emptySummary),
+    );
+
+    return emptySummary;
+  }
+
+  async loadBootstrapConfig(filePath: string): Promise<ExampleBootstrapConfig> {
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(await readFile(filePath, 'utf-8'));
+    } catch (error) {
+      throw new Error(
+        `Could not read bootstrap config at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (!this.isObject(parsed)) {
+      throw new Error('Bootstrap config must be a JSON object');
+    }
+
+    return {
+      projectName: this.optionalString(parsed, 'projectName'),
+      branchName: this.optionalString(parsed, 'branchName'),
+      endpoints: this.parseEndpointArray(parsed.endpoints, 'endpoints'),
+      tables: this.parseTables(parsed.tables),
+      rows: this.parseRows(parsed.rows),
+      commitMessage: this.optionalString(parsed, 'commitMessage'),
+    };
+  }
+
+  formatEndpointHint(url: RevisiumUrlComplete, type: EndpointType): string {
+    const branch = url.branch || 'master';
+    const revision = url.revision || 'draft';
+    const target = `${url.organization}/${url.project}/${branch}/${revision}`;
+
+    if (type === 'GRAPHQL') {
+      return `${url.baseUrl}/endpoint/graphql/${target}`;
+    }
+
+    return `${url.baseUrl}/endpoint/rest/${target}`;
+  }
+
+  async resolveTarget(options: TargetOptions): Promise<RevisiumUrlComplete> {
+    return this.connectionService.resolveTarget(options);
+  }
+
+  parseEndpointType(value: string): EndpointType {
+    if (value !== 'REST_API' && value !== 'GRAPHQL') {
+      throw new Error('Endpoint type must be REST_API or GRAPHQL');
+    }
+    return value;
+  }
+
+  private async createResolvedClient(
+    options: TargetOptions,
+  ): Promise<ResolvedClient> {
+    const url = await this.connectionService.resolveTarget(options);
+    const apiClient = new RevisiumApiClient(url.baseUrl);
+    await apiClient.authenticate(url.auth);
+    return { url, apiClient };
+  }
+
+  private async resolveRevisionScope(
+    url: RevisiumUrlComplete,
+    apiClient: RevisiumApiClient,
+  ): Promise<RevisionScope> {
+    return apiClient.client.revision({
+      org: url.organization,
+      project: url.project,
+      branch: url.branch || 'master',
+      revision: url.revision || 'draft',
+    });
+  }
+
+  private async findEndpoint(
+    revisionScope: RevisionScope,
+    type: EndpointType,
+  ): Promise<EndpointModel | undefined> {
+    const endpoints = await revisionScope.getEndpoints();
+    return endpoints.find((endpoint) => endpoint.type === type);
+  }
+
+  private async ensureTable(
+    revisionScope: RevisionScope,
+    table: BootstrapTableConfig,
+    summary: BootstrapResourceSummary,
+    dryRun: boolean,
+  ): Promise<void> {
+    try {
+      const existingSchema = await revisionScope.getTableSchema(table.id);
+      if (isDeepStrictEqual(existingSchema, table.schema)) {
+        summary.skipped.push(table.id);
+        return;
+      }
+      summary.conflicts.push({
+        id: table.id,
+        reason: 'existing table schema differs from bootstrap config',
+      });
+      return;
+    } catch (error) {
+      if (!this.isNotFoundError(error)) {
+        throw error;
+      }
+    }
+
+    summary.created.push(table.id);
+    if (!dryRun) {
+      await revisionScope.createTable(table.id, table.schema);
+    }
+  }
+
+  private async ensureRow(
+    revisionScope: RevisionScope,
+    row: BootstrapRowConfig,
+    summary: BootstrapResourceSummary,
+    dryRun: boolean,
+  ): Promise<void> {
+    const id = this.formatRowId(row.tableId, row.rowId);
+    const existingRow = await this.findRow(
+      revisionScope,
+      row.tableId,
+      row.rowId,
+    );
+
+    if (existingRow) {
+      if (isDeepStrictEqual(existingRow.data, row.data)) {
+        summary.skipped.push(id);
+        return;
+      }
+      summary.conflicts.push({
+        id,
+        reason: 'existing row data differs from bootstrap config',
+      });
+      return;
+    }
+
+    summary.created.push(id);
+    if (!dryRun) {
+      await revisionScope.createRow(row.tableId, row.rowId, row.data);
+    }
+  }
+
+  private async ensureEndpointOnRevision(
+    revisionScope: RevisionScope,
+    type: EndpointType,
+    summary: BootstrapResourceSummary<EndpointType>,
+    dryRun: boolean,
+  ): Promise<void> {
+    const existing = await this.findEndpoint(revisionScope, type);
+    if (existing) {
+      summary.skipped.push(type);
+      return;
+    }
+
+    summary.created.push(type);
+    if (!dryRun) {
+      await revisionScope.createEndpoint({ type });
+    }
+  }
+
+  private async findRow(
+    revisionScope: RevisionScope,
+    tableId: string,
+    rowId: string,
+  ): Promise<RowModel | undefined> {
+    const rows = await revisionScope.getRows(tableId, {
+      first: 1,
+      where: { id: { equals: rowId } },
+    });
+    return rows.edges[0]?.node;
+  }
+
+  private async commitIfRequested(
+    revisionScope: RevisionScope,
+    commit: boolean | undefined,
+    message: string | undefined,
+    dryRun: boolean,
+    changeCount: number,
+  ): Promise<BootstrapCommitSummary> {
+    if (!commit || changeCount === 0) {
+      return { status: 'skipped' };
+    }
+
+    const commitMessage = message || 'Bootstrap example via revisium-cli';
+
+    if (dryRun) {
+      return { status: 'dry-run', message: commitMessage };
+    }
+
+    const revision = await revisionScope.commit(commitMessage);
+    return {
+      status: 'created',
+      revisionId: revision.id,
+      message: commitMessage,
+    };
+  }
+
+  private buildSkippedCommitSummary(
+    commit: boolean | undefined,
+    message: string | undefined,
+    dryRun: boolean,
+    changeCount: number,
+  ): BootstrapCommitSummary {
+    if (commit && dryRun && changeCount > 0) {
+      return {
+        status: 'dry-run',
+        message: message || 'Bootstrap example via revisium-cli',
+      };
+    }
+    return { status: 'skipped' };
+  }
+
+  private createEmptySummary(
+    url: RevisiumUrlComplete,
+    project: ProjectEnsureResult,
+    dryRun: boolean,
+  ): ExampleBootstrapSummary {
+    return {
+      dryRun,
+      target: {
+        organization: url.organization,
+        project: url.project,
+        branch: url.branch || 'master',
+        revision: url.revision || 'draft',
+      },
+      project,
+      tables: { created: [], skipped: [], conflicts: [] },
+      rows: { created: [], skipped: [], conflicts: [] },
+      endpoints: { created: [], skipped: [], conflicts: [] },
+      commit: { status: 'skipped' },
+    };
+  }
+
+  private countCreated(summary: ExampleBootstrapSummary): number {
+    return (
+      (summary.project.projectStatus === 'created' ? 1 : 0) +
+      (summary.project.branchStatus === 'created' ? 1 : 0) +
+      summary.tables.created.length +
+      summary.rows.created.length +
+      summary.endpoints.created.length
+    );
+  }
+
+  private projectWouldBeCreated(project: ProjectEnsureResult): boolean {
+    return (
+      project.projectStatus === 'created' || project.branchStatus === 'created'
+    );
+  }
+
+  private assertWritableRevision(url: RevisiumUrlComplete): void {
+    if (url.revision !== 'draft') {
+      throw new Error(
+        `Example bootstrap writes tables and rows, so it requires a draft revision. Use ${url.organization}/${url.project}/${url.branch || 'master'}:draft`,
+      );
+    }
+  }
+
+  private assertConfigMatchesTarget(
+    config: ExampleBootstrapConfig,
+    url: RevisiumUrlComplete,
+  ): void {
+    if (config.projectName && config.projectName !== url.project) {
+      throw new Error(
+        `Bootstrap config projectName "${config.projectName}" does not match target project "${url.project}"`,
+      );
+    }
+
+    const branchName = url.branch || 'master';
+    if (config.branchName && config.branchName !== branchName) {
+      throw new Error(
+        `Bootstrap config branchName "${config.branchName}" does not match target branch "${branchName}"`,
+      );
+    }
+  }
+
+  private throwIfConflicts(
+    summary: BootstrapResourceSummary,
+    resourceName: string,
+  ): void {
+    if (summary.conflicts.length === 0) {
+      return;
+    }
+
+    const conflictList = summary.conflicts
+      .map((conflict) => `${conflict.id}: ${conflict.reason}`)
+      .join('; ');
+    throw new Error(`Bootstrap ${resourceName} conflict: ${conflictList}`);
+  }
+
+  private parseEndpointArray(
+    value: unknown,
+    fieldName: string,
+  ): EndpointType[] {
+    if (value === undefined) {
+      return [];
+    }
+    if (!Array.isArray(value)) {
+      throw new Error(`Bootstrap config field "${fieldName}" must be an array`);
+    }
+    return this.uniqueEndpoints(
+      value.map((entry, index) => {
+        if (typeof entry !== 'string') {
+          throw new Error(
+            `Bootstrap config field "${fieldName}[${index}]" must be a string`,
+          );
+        }
+        return this.parseEndpointType(entry);
+      }),
+    );
+  }
+
+  private uniqueEndpoints(values: EndpointType[]): EndpointType[] {
+    return Array.from(new Set(values));
+  }
+
+  private parseTables(value: unknown): BootstrapTableConfig[] {
+    if (value === undefined) {
+      return [];
+    }
+    if (!Array.isArray(value)) {
+      throw new Error('Bootstrap config field "tables" must be an array');
+    }
+    return value.map((entry, index) => {
+      if (!this.isObject(entry)) {
+        throw new Error(`Bootstrap config tables[${index}] must be an object`);
+      }
+      if (typeof entry.id !== 'string' || entry.id.trim() === '') {
+        throw new Error(
+          `Bootstrap config tables[${index}].id must be a non-empty string`,
+        );
+      }
+      if (!this.isObject(entry.schema)) {
+        throw new Error(
+          `Bootstrap config tables[${index}].schema must be an object`,
+        );
+      }
+      return { id: entry.id, schema: entry.schema };
+    });
+  }
+
+  private parseRows(value: unknown): BootstrapRowConfig[] {
+    if (value === undefined) {
+      return [];
+    }
+    if (!Array.isArray(value)) {
+      throw new Error('Bootstrap config field "rows" must be an array');
+    }
+    return value.map((entry, index) => {
+      if (!this.isObject(entry)) {
+        throw new Error(`Bootstrap config rows[${index}] must be an object`);
+      }
+      if (typeof entry.tableId !== 'string' || entry.tableId.trim() === '') {
+        throw new Error(
+          `Bootstrap config rows[${index}].tableId must be a non-empty string`,
+        );
+      }
+      if (typeof entry.rowId !== 'string' || entry.rowId.trim() === '') {
+        throw new Error(
+          `Bootstrap config rows[${index}].rowId must be a non-empty string`,
+        );
+      }
+      if (!this.isObject(entry.data)) {
+        throw new Error(
+          `Bootstrap config rows[${index}].data must be an object`,
+        );
+      }
+      return {
+        tableId: entry.tableId,
+        rowId: entry.rowId,
+        data: entry.data,
+      };
+    });
+  }
+
+  private optionalString(
+    source: Record<string, unknown>,
+    fieldName: string,
+  ): string | undefined {
+    const value = source[fieldName];
+    if (value === undefined) {
+      return undefined;
+    }
+    if (typeof value !== 'string') {
+      throw new Error(`Bootstrap config field "${fieldName}" must be a string`);
+    }
+    return value;
+  }
+
+  private isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  private isNotFoundError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return (
+      message.includes('does not exist') ||
+      message.includes('not found') ||
+      message.includes('Not Found') ||
+      message.includes('404')
+    );
+  }
+
+  private formatRowId(tableId: string, rowId: string): string {
+    return `${tableId}/${rowId}`;
+  }
+}

--- a/src/services/bootstrap/bootstrap.service.ts
+++ b/src/services/bootstrap/bootstrap.service.ts
@@ -209,6 +209,7 @@ export class BootstrapService {
     const config = await this.loadBootstrapConfig(options.configPath);
     const { url, apiClient } = await this.createResolvedClient(options);
     this.assertConfigMatchesTarget(config, url);
+    this.assertWritableRevision(url);
 
     const dryRun = Boolean(options.dryRun);
     const endpoints =
@@ -219,7 +220,7 @@ export class BootstrapService {
     const project = await this.ensureProject(options, dryRun);
     const emptySummary = this.createEmptySummary(url, project, dryRun);
 
-    if (dryRun && this.projectWouldBeCreated(project)) {
+    if (dryRun && project.projectStatus === 'created') {
       emptySummary.tables.created = config.tables.map((table) => table.id);
       emptySummary.rows.created = config.rows.map((row) =>
         this.formatRowId(row.tableId, row.rowId),
@@ -234,8 +235,12 @@ export class BootstrapService {
       return emptySummary;
     }
 
-    const revisionScope = await this.resolveRevisionScope(url, apiClient);
-    this.assertWritableRevision(url);
+    const revisionScope = await this.resolveDiffRevisionScope(
+      url,
+      apiClient,
+      project,
+      dryRun,
+    );
 
     for (const table of config.tables) {
       await this.ensureTable(revisionScope, table, emptySummary.tables, dryRun);
@@ -334,6 +339,27 @@ export class BootstrapService {
       branch: url.branch || 'master',
       revision: url.revision || 'draft',
     });
+  }
+
+  private async resolveDiffRevisionScope(
+    url: RevisiumUrlComplete,
+    apiClient: RevisiumApiClient,
+    project: ProjectEnsureResult,
+    dryRun: boolean,
+  ): Promise<RevisionScope> {
+    if (dryRun && project.branchStatus === 'created') {
+      const projectScope = apiClient.client
+        .org(url.organization)
+        .project(url.project);
+      const rootBranch = await projectScope.branch();
+      return apiClient.client.revision({
+        org: url.organization,
+        project: url.project,
+        branch: rootBranch.branchName,
+        revision: rootBranch.headRevisionId,
+      });
+    }
+    return this.resolveRevisionScope(url, apiClient);
   }
 
   private async findEndpoint(
@@ -502,12 +528,6 @@ export class BootstrapService {
       summary.tables.created.length +
       summary.rows.created.length +
       summary.endpoints.created.length
-    );
-  }
-
-  private projectWouldBeCreated(project: ProjectEnsureResult): boolean {
-    return (
-      project.projectStatus === 'created' || project.branchStatus === 'created'
     );
   }
 

--- a/src/services/bootstrap/bootstrap.service.ts
+++ b/src/services/bootstrap/bootstrap.service.ts
@@ -279,7 +279,7 @@ export class BootstrapService {
     }
 
     if (!this.isObject(parsed)) {
-      throw new Error('Bootstrap config must be a JSON object');
+      throw new TypeError('Bootstrap config must be a JSON object');
     }
 
     return {
@@ -559,12 +559,14 @@ export class BootstrapService {
       return [];
     }
     if (!Array.isArray(value)) {
-      throw new Error(`Bootstrap config field "${fieldName}" must be an array`);
+      throw new TypeError(
+        `Bootstrap config field "${fieldName}" must be an array`,
+      );
     }
     return this.uniqueEndpoints(
       value.map((entry, index) => {
         if (typeof entry !== 'string') {
-          throw new Error(
+          throw new TypeError(
             `Bootstrap config field "${fieldName}[${index}]" must be a string`,
           );
         }
@@ -582,19 +584,21 @@ export class BootstrapService {
       return [];
     }
     if (!Array.isArray(value)) {
-      throw new Error('Bootstrap config field "tables" must be an array');
+      throw new TypeError('Bootstrap config field "tables" must be an array');
     }
     return value.map((entry, index) => {
       if (!this.isObject(entry)) {
-        throw new Error(`Bootstrap config tables[${index}] must be an object`);
+        throw new TypeError(
+          `Bootstrap config tables[${index}] must be an object`,
+        );
       }
       if (typeof entry.id !== 'string' || entry.id.trim() === '') {
-        throw new Error(
+        throw new TypeError(
           `Bootstrap config tables[${index}].id must be a non-empty string`,
         );
       }
       if (!this.isObject(entry.schema)) {
-        throw new Error(
+        throw new TypeError(
           `Bootstrap config tables[${index}].schema must be an object`,
         );
       }
@@ -607,24 +611,26 @@ export class BootstrapService {
       return [];
     }
     if (!Array.isArray(value)) {
-      throw new Error('Bootstrap config field "rows" must be an array');
+      throw new TypeError('Bootstrap config field "rows" must be an array');
     }
     return value.map((entry, index) => {
       if (!this.isObject(entry)) {
-        throw new Error(`Bootstrap config rows[${index}] must be an object`);
+        throw new TypeError(
+          `Bootstrap config rows[${index}] must be an object`,
+        );
       }
       if (typeof entry.tableId !== 'string' || entry.tableId.trim() === '') {
-        throw new Error(
+        throw new TypeError(
           `Bootstrap config rows[${index}].tableId must be a non-empty string`,
         );
       }
       if (typeof entry.rowId !== 'string' || entry.rowId.trim() === '') {
-        throw new Error(
+        throw new TypeError(
           `Bootstrap config rows[${index}].rowId must be a non-empty string`,
         );
       }
       if (!this.isObject(entry.data)) {
-        throw new Error(
+        throw new TypeError(
           `Bootstrap config rows[${index}].data must be an object`,
         );
       }
@@ -645,7 +651,9 @@ export class BootstrapService {
       return undefined;
     }
     if (typeof value !== 'string') {
-      throw new Error(`Bootstrap config field "${fieldName}" must be a string`);
+      throw new TypeError(
+        `Bootstrap config field "${fieldName}" must be a string`,
+      );
     }
     return value;
   }

--- a/src/services/bootstrap/index.ts
+++ b/src/services/bootstrap/index.ts
@@ -1,0 +1,12 @@
+export {
+  BootstrapService,
+  BootstrapCommitSummary,
+  BootstrapConflict,
+  BootstrapResourceSummary,
+  EndpointEnsureResult,
+  EndpointType,
+  ExampleBootstrapOptions,
+  ExampleBootstrapSummary,
+  ProjectEnsureResult,
+  TargetOptions,
+} from './bootstrap.service';

--- a/src/services/connection/__tests__/connection-factory.service.spec.ts
+++ b/src/services/connection/__tests__/connection-factory.service.spec.ts
@@ -159,6 +159,7 @@ describe('ConnectionFactoryService', () => {
 
       expect(mockOrgScope.createProject).toHaveBeenCalledWith({
         projectName: 'test-project',
+        branchName: 'main',
       });
       expect(result.revisionScope).toBe(mockDraftScope);
       expect(loggerFake.info).toHaveBeenCalledWith(
@@ -225,6 +226,7 @@ describe('ConnectionFactoryService', () => {
 
       expect(mockOrgScope.createProject).toHaveBeenCalledWith({
         projectName: 'test-project',
+        branchName: 'main',
       });
       expect(result.revisionScope).toBe(mockDraftScope);
     });

--- a/src/services/connection/connection-factory.service.ts
+++ b/src/services/connection/connection-factory.service.ts
@@ -90,9 +90,10 @@ export class ConnectionFactoryService {
           `Project "${url.project}" not found — creating automatically`,
         );
 
-        await client.client
-          .org(url.organization)
-          .createProject({ projectName: url.project });
+        await client.client.org(url.organization).createProject({
+          projectName: url.project,
+          branchName: url.branch || 'master',
+        });
 
         return client.client.branch(branchOptions);
       }

--- a/src/services/connection/connection.service.ts
+++ b/src/services/connection/connection.service.ts
@@ -41,12 +41,17 @@ export class ConnectionService {
   }
 
   public async connect(options: ConnectionOptions = {}): Promise<void> {
-    const env = this.getEnvConfig();
-    const url = await this.resolveUrl(options, env);
+    const url = await this.resolveTarget(options);
 
     this._connection = await this.connectionFactory.createConnection(url, {
       createProject: options.createProject,
     });
+  }
+
+  public async resolveTarget(
+    options: ConnectionOptions = {},
+  ): Promise<RevisiumUrlComplete> {
+    return this.resolveUrl(options, this.getEnvConfig());
   }
 
   private async resolveUrl(

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -4,3 +4,4 @@ export * from './sync';
 export * from './common';
 export * from './workspace';
 export * from './credentials';
+export * from './bootstrap';


### PR DESCRIPTION
## Summary
- add project/endpoint/example command groups for idempotent example bootstrap
- add BootstrapService with project/branch ensure, endpoint ensure/list, config validation, dry-run, JSON summaries, endpoint overrides, and optional commit
- add docs plus unit and focused e2e coverage for idempotent bootstrap against standalone

## Validation
- npm run tsc
- npm run lint:ci
- npm test -- --runInBand
- npm run build
- npm run test:e2e -- --runTestsByPath e2e/tests/08-bootstrap.e2e-spec.ts
- npm view @revisium/standalone version -> 2.8.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI commands: project ensure, endpoint ensure, endpoint list, and example bootstrap. Commands are idempotent and support --dry-run, --json, --commit and repeatable --endpoint overrides.

* **Documentation**
  * README updated with bootstrap command entries and added a dedicated Bootstrap Commands guide.

* **Tests**
  * Added end-to-end and unit tests covering bootstrap, project, endpoint, and example command behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-cli/pull/73)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->