### PR TITLE
feat: add saved API key auth commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,19 +133,20 @@ revisium sync all \
 
 ## Commands
 
-| Command | Description | Documentation |
-|---------|-------------|---------------|
-| `schema save` | Export table schemas to JSON files | [Schema Commands](docs/schema-commands.md) |
-| `schema create-migrations` | Convert schemas to migration format | [Schema Commands](docs/schema-commands.md) |
-| `migrate save` | Export migrations to JSON file | [Migrate Commands](docs/migrate-commands.md) |
-| `migrate apply` | Apply migrations from JSON file | [Migrate Commands](docs/migrate-commands.md) |
-| `rows save` | Export table data to JSON files | [Rows Commands](docs/rows-commands.md) |
-| `rows upload` | Upload table data from JSON files | [Rows Commands](docs/rows-commands.md) |
-| `sync schema` | Sync schema between projects | [Sync Commands](docs/sync-commands.md) |
-| `sync data` | Sync data between projects | [Sync Commands](docs/sync-commands.md) |
-| `sync all` | Full sync (schema + data) | [Sync Commands](docs/sync-commands.md) |
-| `instance add/list/show/remove` | Manage workspace Revisium instances | [Workspace Config](docs/workspace-config.md) |
-| `context create/list/show/use/remove` | Manage workspace Revisium contexts | [Workspace Config](docs/workspace-config.md) |
+| Command                               | Description                         | Documentation                                |
+| ------------------------------------- | ----------------------------------- | -------------------------------------------- |
+| `schema save`                         | Export table schemas to JSON files  | [Schema Commands](docs/schema-commands.md)   |
+| `schema create-migrations`            | Convert schemas to migration format | [Schema Commands](docs/schema-commands.md)   |
+| `migrate save`                        | Export migrations to JSON file      | [Migrate Commands](docs/migrate-commands.md) |
+| `migrate apply`                       | Apply migrations from JSON file     | [Migrate Commands](docs/migrate-commands.md) |
+| `rows save`                           | Export table data to JSON files     | [Rows Commands](docs/rows-commands.md)       |
+| `rows upload`                         | Upload table data from JSON files   | [Rows Commands](docs/rows-commands.md)       |
+| `sync schema`                         | Sync schema between projects        | [Sync Commands](docs/sync-commands.md)       |
+| `sync data`                           | Sync data between projects          | [Sync Commands](docs/sync-commands.md)       |
+| `sync all`                            | Full sync (schema + data)           | [Sync Commands](docs/sync-commands.md)       |
+| `instance add/list/show/remove`       | Manage workspace Revisium instances | [Workspace Config](docs/workspace-config.md) |
+| `context create/list/show/use/remove` | Manage workspace Revisium contexts  | [Workspace Config](docs/workspace-config.md) |
+| `auth login/status/logout`            | Manage saved API-key credentials    | [Authentication](docs/authentication.md)     |
 
 ## Configuration
 

--- a/docs/auth-contexts-and-bootstrap-plan.md
+++ b/docs/auth-contexts-and-bootstrap-plan.md
@@ -16,28 +16,27 @@ Revisium CLI currently resolves connection details from `--url`, environment var
 
 This document started as a forward-looking plan. Keep this section updated as each phase lands so the next implementation step is visible from `master`.
 
-| Area | Status | Notes |
-| --- | --- | --- |
-| Workspace config path | Done | The CLI uses nearest `.revisium/revisium-cli.config.json`; there is no home-level CLI config. |
-| Instance commands | Done | `instance add/list/show/remove` manage non-secret workspace instance aliases. |
-| Context commands | Done | `context create/list/show/use/remove` manage default workspace targets and `currentContext`. |
-| Workspace target resolution | Done | Single-target commands can use `--context` or current workspace context when `--url` / `REVISIUM_URL` are absent. |
-| Explicit no-auth mode | Done | `authMode: "none"` supports local standalone examples without credentials. |
-| Stored auth mode shape | Partial | `authMode: "stored"` and optional context `credential` are reserved, but saved credentials are not implemented yet. |
-| Auth commands | Not started | `auth login/status/logout` still need an OS credential-store backed implementation. |
-| Credential-store abstraction | Not started | Needed before saving API keys or OAuth refresh material. |
-| Shared client error/ensure helpers | Not started | `@revisium/client` still needs reusable structured errors and idempotent ensure helpers. |
-| Project and endpoint ensure commands | Not started | `project ensure`, `endpoint ensure`, and `endpoint list` are still planned CLI work. |
-| Example bootstrap command | Not started | `example bootstrap` remains planned and should be added after or with reusable ensure helpers. |
-| Common output flags | Partial | `--context` exists for single-target commands; `--json`, `--quiet`, and `--no-input` still need consistent command-wide behavior. |
-| `revisium-examples` adoption | Blocked | Wait for released CLI support before replacing custom bootstrap scripts. |
+| Area                                 | Status            | Notes                                                                                                                             |
+| ------------------------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Workspace config path                | Done              | The CLI uses nearest `.revisium/revisium-cli.config.json`; there is no home-level CLI config.                                     |
+| Instance commands                    | Done              | `instance add/list/show/remove` manage non-secret workspace instance aliases.                                                     |
+| Context commands                     | Done              | `context create/list/show/use/remove` manage default workspace targets and `currentContext`.                                      |
+| Workspace target resolution          | Done              | Single-target commands can use `--context` or current workspace context when `--url` / `REVISIUM_URL` are absent.                 |
+| Explicit no-auth mode                | Done              | `authMode: "none"` supports local standalone examples without credentials.                                                        |
+| Stored auth mode shape               | Done for API keys | `authMode: "stored"` resolves named API-key credentials after explicit URL/env auth.                                              |
+| Auth commands                        | Done for API keys | `auth login/status/logout` manage saved API-key credentials. OAuth remains future scope.                                          |
+| Credential-store abstraction         | Done for API keys | API keys are stored in the OS credential store; OAuth refresh material remains future scope.                                      |
+| Shared client error/ensure helpers   | Not started       | `@revisium/client` still needs reusable structured errors and idempotent ensure helpers.                                          |
+| Project and endpoint ensure commands | Not started       | `project ensure`, `endpoint ensure`, and `endpoint list` are still planned CLI work.                                              |
+| Example bootstrap command            | Not started       | `example bootstrap` remains planned and should be added after or with reusable ensure helpers.                                    |
+| Common output flags                  | Partial           | `--context` exists for single-target commands; `--json`, `--quiet`, and `--no-input` still need consistent command-wide behavior. |
+| `revisium-examples` adoption         | Blocked           | Wait for released CLI support before replacing custom bootstrap scripts.                                                          |
 
 Recommended next PR sequence:
 
-1. Finish credential foundation in `revisium-cli`: credential-store abstraction plus `auth login/status/logout` for API keys.
-2. Add reusable structured errors and idempotent ensure helpers in `@revisium/client`.
-3. Add `project ensure`, `endpoint ensure/list`, and `example bootstrap` in `revisium-cli`, using client helpers where available.
-4. Update `revisium-examples` after the CLI commands are released.
+1. Add reusable structured errors and idempotent ensure helpers in `@revisium/client`.
+2. Add `project ensure`, `endpoint ensure/list`, and `example bootstrap` in `revisium-cli`, using client helpers where available.
+3. Update `revisium-examples` after the CLI commands are released.
 
 ## Goals
 
@@ -61,11 +60,11 @@ Recommended next PR sequence:
 
 Use three related concepts:
 
-| Concept | Meaning | Secret? | Example |
-| --- | --- | --- | --- |
-| Instance | Revisium server location | No | `local` -> `revisium://localhost:9222` |
-| Credential | Auth material for an instance | Yes | API key, OAuth refresh token |
-| Context | Default target path | No | `local/admin/dictionary/master:draft` |
+| Concept    | Meaning                       | Secret? | Example                                |
+| ---------- | ----------------------------- | ------- | -------------------------------------- |
+| Instance   | Revisium server location      | No      | `local` -> `revisium://localhost:9222` |
+| Credential | Auth material for an instance | Yes     | API key, OAuth refresh token           |
+| Context    | Default target path           | No      | `local/admin/dictionary/master:draft`  |
 
 Instances and contexts are stored in the workspace config. Credentials are stored outside the workspace in the OS credential store.
 
@@ -196,10 +195,10 @@ Credential-store unavailability should fail only when this precedence reaches a 
 
 For sync commands, preserve the source/target variants before falling back to saved credentials:
 
-| Endpoint | URL | Token | API key | Username | Password |
-| --- | --- | --- | --- | --- | --- |
-| Source | `REVISIUM_SOURCE_URL` | `REVISIUM_SOURCE_TOKEN` | `REVISIUM_SOURCE_API_KEY` | `REVISIUM_SOURCE_USERNAME` | `REVISIUM_SOURCE_PASSWORD` |
-| Target | `REVISIUM_TARGET_URL` | `REVISIUM_TARGET_TOKEN` | `REVISIUM_TARGET_API_KEY` | `REVISIUM_TARGET_USERNAME` | `REVISIUM_TARGET_PASSWORD` |
+| Endpoint | URL                   | Token                   | API key                   | Username                   | Password                   |
+| -------- | --------------------- | ----------------------- | ------------------------- | -------------------------- | -------------------------- |
+| Source   | `REVISIUM_SOURCE_URL` | `REVISIUM_SOURCE_TOKEN` | `REVISIUM_SOURCE_API_KEY` | `REVISIUM_SOURCE_USERNAME` | `REVISIUM_SOURCE_PASSWORD` |
+| Target   | `REVISIUM_TARGET_URL` | `REVISIUM_TARGET_TOKEN` | `REVISIUM_TARGET_API_KEY` | `REVISIUM_TARGET_USERNAME` | `REVISIUM_TARGET_PASSWORD` |
 
 If mutually exclusive auth methods are supplied, keep the current conflict handling and fail with a clear message instead of silently choosing a different credential.
 
@@ -336,11 +335,13 @@ Config shape:
   "projectName": "dictionary",
   "branchName": "master",
   "endpoints": ["REST_API", "GRAPHQL"],
-  "tables": [
-    { "id": "FaqCategory", "schema": { "type": "object" } }
-  ],
+  "tables": [{ "id": "FaqCategory", "schema": { "type": "object" } }],
   "rows": [
-    { "tableId": "FaqCategory", "rowId": "billing", "data": { "name": "Billing" } }
+    {
+      "tableId": "FaqCategory",
+      "rowId": "billing",
+      "data": { "name": "Billing" }
+    }
   ],
   "commitMessage": "Bootstrap dictionary example"
 }
@@ -436,7 +437,11 @@ Example JSON output:
   "context": "dictionary-local",
   "tables": { "created": 2, "skipped": 3, "conflicts": [] },
   "rows": { "created": 12, "skipped": 0, "conflicts": [] },
-  "endpoints": { "created": ["REST_API"], "skipped": ["GRAPHQL"], "conflicts": [] },
+  "endpoints": {
+    "created": ["REST_API"],
+    "skipped": ["GRAPHQL"],
+    "conflicts": []
+  },
   "commit": { "status": "created", "revisionId": "rev_123" }
 }
 ```
@@ -475,13 +480,13 @@ If endpoint service public URL differs from core base URL, the server should exp
 - [ ] Add client ensure helpers.
 - [ ] Add unit/integration tests for idempotency.
 - [x] Add workspace CLI config service for non-secret instances and contexts at `.revisium/revisium-cli.config.json`.
-- [ ] Add credential-store abstraction with named credentials and an in-memory fake for tests.
+- [x] Add credential-store abstraction with named credentials and test fakes.
 - [x] Add explicit no-auth connection mode for local standalone workflows.
 
 ### Phase 2: Auth And Context Commands
 
 - [x] Implement `instance` commands.
-- [ ] Implement `auth login/status/logout` for API keys.
+- [x] Implement `auth login/status/logout` for API keys.
 - [x] Implement `context` commands.
 - [ ] Add common `--context`, `--json`, `--quiet`, and `--no-input` behavior. `--context` is implemented for single-target commands; the output/non-interactive flags still need consistent handling.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -26,18 +26,42 @@ revisium schema save --folder ./schemas --url revisium://cloud.revisium.io/org/p
 
 API key for automated and programmatic access. Keys use the `rev_` prefix and are sent via the `X-Api-Key` header (recommended over Bearer for API keys).
 
-### Usage
+### Saved API Key
 
 ```bash
-# In URL query parameter
-revisium://cloud.revisium.io/org/proj?apikey=rev_xxxxxxxxxxxxxxxxxxxx
+revisium instance add cloud --url revisium://cloud.revisium.io --auth stored
+revisium context create dictionary-cloud \
+  --url revisium://cloud.revisium.io/org/proj/master \
+  --credential default
+revisium context use dictionary-cloud
 
-# Via environment variable
-export REVISIUM_API_KEY=rev_xxxxxxxxxxxxxxxxxxxx
+revisium auth login --instance cloud --api-key
+revisium schema save --folder ./schemas
 ```
 
-**Personal keys** are linked to a user account — `me()` returns the key owner.
-**Service keys** are not linked to a user — the CLI displays "service account" instead of a username.
+`auth login --api-key` prompts with hidden input and stores the key in the operating system credential store. The workspace config stores only the instance, context, and credential name. To script setup, use stdin:
+
+```bash
+printf '%s\n' "$REVISIUM_API_KEY" | \
+  revisium auth login --instance cloud --credential default --api-key-stdin
+```
+
+Use `auth status` to check whether a credential exists and `auth logout` to delete it:
+
+```bash
+revisium auth status --instance cloud
+revisium auth logout --instance cloud
+```
+
+### One-Off Usage
+
+```bash
+# In URL query parameter, useful for compatibility but avoid shell history leaks
+revisium://cloud.revisium.io/org/proj?apikey=rev_xxxxxxxxxxxxxxxxxxxx
+
+# Via environment variable, useful for CI
+export REVISIUM_API_KEY=rev_xxxxxxxxxxxxxxxxxxxx
+```
 
 ## Password Authentication
 
@@ -85,33 +109,34 @@ Paste token: ****
 
 ### For All Commands (Single Endpoint)
 
-| Variable | Description |
-|----------|-------------|
-| `REVISIUM_URL` | Default URL (e.g., `revisium://host/org/project/branch`) |
-| `REVISIUM_TOKEN` | JWT authentication token |
-| `REVISIUM_API_KEY` | API key (for automated access) |
-| `REVISIUM_USERNAME` | Username (for password auth) |
-| `REVISIUM_PASSWORD` | Password (for password auth) |
+| Variable            | Description                                              |
+| ------------------- | -------------------------------------------------------- |
+| `REVISIUM_URL`      | Default URL (e.g., `revisium://host/org/project/branch`) |
+| `REVISIUM_TOKEN`    | JWT authentication token                                 |
+| `REVISIUM_API_KEY`  | API key (for automated access)                           |
+| `REVISIUM_USERNAME` | Username (for password auth)                             |
+| `REVISIUM_PASSWORD` | Password (for password auth)                             |
 
 ### For Sync Commands (Source/Target)
 
-| Variable | Description |
-|----------|-------------|
-| `REVISIUM_SOURCE_TOKEN` | Source project token |
-| `REVISIUM_SOURCE_API_KEY` | Source project API key |
-| `REVISIUM_SOURCE_USERNAME` | Source username |
-| `REVISIUM_SOURCE_PASSWORD` | Source password |
-| `REVISIUM_TARGET_TOKEN` | Target project token |
-| `REVISIUM_TARGET_API_KEY` | Target project API key |
-| `REVISIUM_TARGET_USERNAME` | Target username |
-| `REVISIUM_TARGET_PASSWORD` | Target password |
+| Variable                   | Description            |
+| -------------------------- | ---------------------- |
+| `REVISIUM_SOURCE_TOKEN`    | Source project token   |
+| `REVISIUM_SOURCE_API_KEY`  | Source project API key |
+| `REVISIUM_SOURCE_USERNAME` | Source username        |
+| `REVISIUM_SOURCE_PASSWORD` | Source password        |
+| `REVISIUM_TARGET_TOKEN`    | Target project token   |
+| `REVISIUM_TARGET_API_KEY`  | Target project API key |
+| `REVISIUM_TARGET_USERNAME` | Target username        |
+| `REVISIUM_TARGET_PASSWORD` | Target password        |
 
 ## Priority
 
 1. **URL auth** (`?token=...`, `?apikey=...`, or `user:pass@host`)
 2. **Environment variables** (`TOKEN` > `API_KEY` > `USERNAME/PASSWORD`)
 3. **Workspace no-auth mode** (`authMode: "none"`)
-4. **Interactive prompts**
+4. **Saved workspace credential** (`authMode: "stored"`)
+5. **Interactive prompts**
 
 ## Validation
 
@@ -173,4 +198,4 @@ revisium sync all \
 
 - [URL Format](./url-format.md) - URL syntax
 - [Configuration](./configuration.md) - Environment variables
-- [Workspace Config](./workspace-config.md) - no-auth local contexts
+- [Workspace Config](./workspace-config.md) - workspace instances and contexts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ revisium context use dictionary-local
 revisium schema save --folder ./schemas
 ```
 
-The workspace config stores only non-secret instance and context data. Keep tokens, API keys, and passwords in environment variables or explicit URL/auth inputs.
+The workspace config stores only non-secret instance and context data. API keys can be saved in the operating system credential store with `revisium auth login`; tokens and passwords should stay in environment variables or explicit URL/auth inputs.
 
 See [Workspace Config](./workspace-config.md).
 
@@ -23,28 +23,28 @@ All commands support configuration via environment variables.
 
 ### Single-Endpoint Commands (schema, migrate, rows)
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `REVISIUM_URL` | Revisium URL (see [URL Format](./url-format.md)) | `revisium://cloud.revisium.io/org/proj/main` |
-| `REVISIUM_TOKEN` | JWT authentication token | `eyJhbGciOiJIUzI1NiIs...` |
-| `REVISIUM_API_KEY` | API key (for automated access) | `rev_xxxxxxxxxxxxx` |
-| `REVISIUM_USERNAME` | Username (for password auth) | `admin` |
-| `REVISIUM_PASSWORD` | Password (for password auth) | `secret` |
+| Variable            | Description                                      | Example                                      |
+| ------------------- | ------------------------------------------------ | -------------------------------------------- |
+| `REVISIUM_URL`      | Revisium URL (see [URL Format](./url-format.md)) | `revisium://cloud.revisium.io/org/proj/main` |
+| `REVISIUM_TOKEN`    | JWT authentication token                         | `eyJhbGciOiJIUzI1NiIs...`                    |
+| `REVISIUM_API_KEY`  | API key (for automated access)                   | `rev_xxxxxxxxxxxxx`                          |
+| `REVISIUM_USERNAME` | Username (for password auth)                     | `admin`                                      |
+| `REVISIUM_PASSWORD` | Password (for password auth)                     | `secret`                                     |
 
 ### Sync Commands (source/target)
 
-| Variable | Description |
-|----------|-------------|
-| `REVISIUM_SOURCE_URL` | Source project URL |
-| `REVISIUM_SOURCE_TOKEN` | Source JWT token |
-| `REVISIUM_SOURCE_API_KEY` | Source API key |
-| `REVISIUM_SOURCE_USERNAME` | Source username |
-| `REVISIUM_SOURCE_PASSWORD` | Source password |
-| `REVISIUM_TARGET_URL` | Target project URL |
-| `REVISIUM_TARGET_TOKEN` | Target JWT token |
-| `REVISIUM_TARGET_API_KEY` | Target API key |
-| `REVISIUM_TARGET_USERNAME` | Target username |
-| `REVISIUM_TARGET_PASSWORD` | Target password |
+| Variable                   | Description        |
+| -------------------------- | ------------------ |
+| `REVISIUM_SOURCE_URL`      | Source project URL |
+| `REVISIUM_SOURCE_TOKEN`    | Source JWT token   |
+| `REVISIUM_SOURCE_API_KEY`  | Source API key     |
+| `REVISIUM_SOURCE_USERNAME` | Source username    |
+| `REVISIUM_SOURCE_PASSWORD` | Source password    |
+| `REVISIUM_TARGET_URL`      | Target project URL |
+| `REVISIUM_TARGET_TOKEN`    | Target JWT token   |
+| `REVISIUM_TARGET_API_KEY`  | Target API key     |
+| `REVISIUM_TARGET_USERNAME` | Target username    |
+| `REVISIUM_TARGET_PASSWORD` | Target password    |
 
 ### Authentication Priority
 
@@ -55,7 +55,12 @@ For explicit URLs and environment targets, authentication is resolved in this or
 3. **Environment variable** - `REVISIUM_TOKEN` > `REVISIUM_API_KEY` > `REVISIUM_USERNAME/PASSWORD`
 4. **Interactive prompt** - if running in terminal
 
-When a workspace context is used, URL and environment auth still win. If the selected instance has `authMode: "none"`, the CLI sends no auth. `authMode: "stored"` currently requires URL or environment credentials until saved credential commands are implemented.
+When a workspace context is used, URL and environment auth still win. If the selected instance has `authMode: "none"`, the CLI sends no auth. If the selected instance has `authMode: "stored"`, the CLI reads the selected named API-key credential from the operating system credential store.
+
+```bash
+revisium auth login --instance cloud --credential default --api-key
+revisium auth status --instance cloud
+```
 
 **Important:** You can use `--url` to specify host/org/project/branch and provide credentials via environment:
 
@@ -121,7 +126,8 @@ Configuration is resolved in this order (highest to lowest):
 1. **Command-line target options** (`--url`, `--context`)
 2. **Environment variables** (`REVISIUM_URL`, `REVISIUM_TOKEN`, etc.)
 3. **Current workspace context** (`.revisium/revisium-cli.config.json`)
-4. **Interactive prompts** (for missing values)
+4. **Saved API-key credential** for stored workspace contexts
+5. **Interactive prompts** (for missing values)
 
 ## Examples
 

--- a/docs/workspace-config.md
+++ b/docs/workspace-config.md
@@ -49,20 +49,27 @@ organization, project, branch, and revision. It should not contain credentials.
 
 ## Authenticated Instances
 
-For authenticated instances, keep secrets in environment variables for now. The workspace config should describe the target,
-while credentials come from the shell or CI secret store:
+For authenticated local use, keep the target in workspace config and save API keys in the operating system credential store:
 
 ```bash
 revisium instance add cloud --url revisium://cloud.revisium.io --auth stored
 revisium context create dictionary-cloud \
-  --url revisium://cloud.revisium.io/admin/dictionary/master
+  --url revisium://cloud.revisium.io/admin/dictionary/master \
+  --credential default
 revisium context use dictionary-cloud
 
-export REVISIUM_API_KEY=rev_xxxxxxxxxxxxxxxxxxxx
+revisium auth login --instance cloud --api-key
 revisium schema save --folder ./schemas
 ```
 
-`authMode: "stored"` reserves the workspace shape for named stored credentials, but this implementation does not save API keys to an OS credential store yet. If no URL or environment credentials are available, stored mode fails with a remediation message. The optional context `credential` field is written only when `--credential` is passed.
+`authMode: "stored"` resolves the selected named credential after explicit URL and environment credentials. The optional context `credential` field selects the saved credential name and defaults to `default` when omitted. API keys are stored outside the workspace under a key based on normalized instance base URL plus credential name, so workspace aliases can differ between projects without moving the secret.
+
+For CI, prefer environment variables instead of saved local credentials:
+
+```bash
+export REVISIUM_API_KEY=rev_xxxxxxxxxxxxxxxxxxxx
+revisium schema save --folder ./schemas
+```
 
 URL-embedded credentials such as `revisium://user:pass@host`, `?token=...`, and `?apikey=...` remain supported for compatibility
 and emergencies, but avoid them in normal usage because they can leak through shell history, process listings, and logs.
@@ -74,6 +81,10 @@ revisium instance add <name> --url <revisium-server-url> [--auth none|stored]
 revisium instance list
 revisium instance show <name>
 revisium instance remove <name>
+
+revisium auth login (--instance <name> | --url <revisium-url>) [--credential <name>] (--api-key | --api-key-stdin) [--force]
+revisium auth status [--instance <name> | --url <revisium-url>] [--credential <name>]
+revisium auth logout [--instance <name> | --url <revisium-url>] [--credential <name>]
 
 revisium context create <name> --url <revisium-url> [--instance <name>] [--credential <name>]
 revisium context create <name> --instance <name> --org <org> --project <project> [--branch <branch>] [--revision <revision>]
@@ -118,7 +129,7 @@ Authentication remains explicit:
 1. Environment auth: `REVISIUM_TOKEN` > `REVISIUM_API_KEY` > `REVISIUM_USERNAME` / `REVISIUM_PASSWORD`
 2. URL auth, discouraged except for compatibility or emergencies: `?token=...`, `?apikey=...`, or `user:password@host`
 3. Workspace `authMode: "none"`
-4. Stored credentials in a future implementation
+4. Stored API-key credentials when the instance uses `authMode: "stored"`
 5. Interactive prompt for non-workspace URL flows
 
 Sync commands still use `--source`, `--target`, and the `REVISIUM_SOURCE_*` / `REVISIUM_TARGET_*` environment variables.

--- a/docs/workspace-config.md
+++ b/docs/workspace-config.md
@@ -126,8 +126,8 @@ For single-target commands, command target options win first: `--url` selects an
 
 Authentication remains explicit:
 
-1. Environment auth: `REVISIUM_TOKEN` > `REVISIUM_API_KEY` > `REVISIUM_USERNAME` / `REVISIUM_PASSWORD`
-2. URL auth, discouraged except for compatibility or emergencies: `?token=...`, `?apikey=...`, or `user:password@host`
+1. URL auth, discouraged except for compatibility or emergencies: `?token=...`, `?apikey=...`, or `user:password@host`
+2. Environment auth: `REVISIUM_TOKEN` > `REVISIUM_API_KEY` > `REVISIUM_USERNAME` / `REVISIUM_PASSWORD`
 3. Workspace `authMode: "none"`
 4. Stored API-key credentials when the instance uses `authMode: "stored"`
 5. Interactive prompt for non-workspace URL flows

--- a/e2e/tests/07-workspace-config.e2e-spec.ts
+++ b/e2e/tests/07-workspace-config.e2e-spec.ts
@@ -10,13 +10,14 @@ import { FIXTURES_PATH } from '../utils/constants';
 
 const REPO_ROOT = process.cwd();
 const MIGRATIONS_FILE = path.join(REPO_ROOT, FIXTURES_PATH, 'migrations.json');
+const E2E_CREDENTIAL_STORE_SERVICE = `revisium-cli-e2e-${process.pid}-${Date.now()}`;
 const CLEAR_REVISIUM_ENV = {
   REVISIUM_URL: '',
   REVISIUM_TOKEN: '',
   REVISIUM_API_KEY: '',
   REVISIUM_USERNAME: '',
   REVISIUM_PASSWORD: '',
-  REVISIUM_CREDENTIAL_STORE_SERVICE: 'revisium-cli-e2e',
+  REVISIUM_CREDENTIAL_STORE_SERVICE: E2E_CREDENTIAL_STORE_SERVICE,
 };
 
 interface WorkspaceConfig {

--- a/e2e/tests/07-workspace-config.e2e-spec.ts
+++ b/e2e/tests/07-workspace-config.e2e-spec.ts
@@ -16,6 +16,7 @@ const CLEAR_REVISIUM_ENV = {
   REVISIUM_API_KEY: '',
   REVISIUM_USERNAME: '',
   REVISIUM_PASSWORD: '',
+  REVISIUM_CREDENTIAL_STORE_SERVICE: 'revisium-cli-e2e',
 };
 
 interface WorkspaceConfig {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.1.0",
+        "@napi-rs/keyring": "^1.3.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -2992,6 +2993,240 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/nice": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.1.0",
+    "@napi-rs/keyring": "^1.3.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { AuthCommand } from 'src/commands/auth/auth.command';
+import { AuthLoginCommand } from 'src/commands/auth/auth-login.command';
+import { AuthLogoutCommand } from 'src/commands/auth/auth-logout.command';
+import { AuthStatusCommand } from 'src/commands/auth/auth-status.command';
 import { ApplyMigrationsCommand } from 'src/commands/migration/apply-migrations.command';
 import { ContextCommand } from 'src/commands/context/context.command';
 import { ContextCreateCommand } from 'src/commands/context/context-create.command';
@@ -52,6 +56,10 @@ import {
   shouldIgnoreEnvFile,
 } from 'src/utils/env-config.utils';
 import { WorkspaceConfigService } from 'src/services/workspace';
+import {
+  CredentialStoreService,
+  CredentialTargetService,
+} from 'src/services/credentials';
 
 @Module({
   imports: [
@@ -65,6 +73,10 @@ import { WorkspaceConfigService } from 'src/services/workspace';
     MigrationCommand,
     ApplyMigrationsCommand,
     SaveMigrationsCommand,
+    AuthCommand,
+    AuthLoginCommand,
+    AuthStatusCommand,
+    AuthLogoutCommand,
     InstanceCommand,
     InstanceAddCommand,
     InstanceListCommand,
@@ -102,6 +114,8 @@ import { WorkspaceConfigService } from 'src/services/workspace';
     UrlParserService,
     AuthPromptService,
     WorkspaceConfigService,
+    CredentialStoreService,
+    CredentialTargetService,
   ],
 })
 export class AppModule {}

--- a/src/commands/auth/__tests__/auth-command.utils.spec.ts
+++ b/src/commands/auth/__tests__/auth-command.utils.spec.ts
@@ -1,0 +1,39 @@
+import {
+  formatAuthLoginHint,
+  formatAuthRevisiumUrl,
+  formatAuthTarget,
+} from '../auth-command.utils';
+
+describe('auth command formatting helpers', () => {
+  it('formats instance and URL targets consistently', () => {
+    expect(formatAuthTarget('cloud', 'https://cloud.revisium.io')).toBe(
+      'instance "cloud" (https://cloud.revisium.io)',
+    );
+    expect(formatAuthTarget(undefined, 'https://cloud.revisium.io')).toBe(
+      'https://cloud.revisium.io',
+    );
+  });
+
+  it('formats login hints for instance and URL targets', () => {
+    expect(
+      formatAuthLoginHint({
+        instanceName: 'cloud',
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'admin',
+      }),
+    ).toBe('--instance cloud --credential admin --api-key');
+
+    expect(
+      formatAuthLoginHint({
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'default',
+      }),
+    ).toBe('--url revisium://cloud.revisium.io --credential default --api-key');
+  });
+
+  it('formats HTTP base URLs as revisium URLs', () => {
+    expect(formatAuthRevisiumUrl('http://localhost:9222')).toBe(
+      'revisium://localhost:9222',
+    );
+  });
+});

--- a/src/commands/auth/__tests__/auth-command.utils.spec.ts
+++ b/src/commands/auth/__tests__/auth-command.utils.spec.ts
@@ -21,19 +21,21 @@ describe('auth command formatting helpers', () => {
         baseUrl: 'https://cloud.revisium.io',
         credential: 'admin',
       }),
-    ).toBe('--instance cloud --credential admin --api-key');
+    ).toBe('--instance "cloud" --credential "admin" --api-key');
 
     expect(
       formatAuthLoginHint({
         baseUrl: 'https://cloud.revisium.io',
         credential: 'default',
       }),
-    ).toBe('--url revisium://cloud.revisium.io --credential default --api-key');
+    ).toBe(
+      '--url "revisium://cloud.revisium.io" --credential "default" --api-key',
+    );
   });
 
   it('formats HTTP base URLs as revisium URLs', () => {
     expect(formatAuthRevisiumUrl('http://localhost:9222')).toBe(
-      'revisium://localhost:9222',
+      'revisium+http://localhost:9222',
     );
   });
 });

--- a/src/commands/auth/__tests__/auth-command.utils.spec.ts
+++ b/src/commands/auth/__tests__/auth-command.utils.spec.ts
@@ -21,7 +21,7 @@ describe('auth command formatting helpers', () => {
         baseUrl: 'https://cloud.revisium.io',
         credential: 'admin',
       }),
-    ).toBe('--instance "cloud" --credential "admin" --api-key');
+    ).toBe('--instance \'cloud\' --credential \'admin\' --api-key');
 
     expect(
       formatAuthLoginHint({
@@ -29,7 +29,7 @@ describe('auth command formatting helpers', () => {
         credential: 'default',
       }),
     ).toBe(
-      '--url "revisium://cloud.revisium.io" --credential "default" --api-key',
+      '--url \'revisium://cloud.revisium.io\' --credential \'default\' --api-key',
     );
   });
 

--- a/src/commands/auth/__tests__/auth-command.utils.spec.ts
+++ b/src/commands/auth/__tests__/auth-command.utils.spec.ts
@@ -21,7 +21,7 @@ describe('auth command formatting helpers', () => {
         baseUrl: 'https://cloud.revisium.io',
         credential: 'admin',
       }),
-    ).toBe('--instance \'cloud\' --credential \'admin\' --api-key');
+    ).toBe("--instance 'cloud' --credential 'admin' --api-key");
 
     expect(
       formatAuthLoginHint({
@@ -29,7 +29,7 @@ describe('auth command formatting helpers', () => {
         credential: 'default',
       }),
     ).toBe(
-      '--url \'revisium://cloud.revisium.io\' --credential \'default\' --api-key',
+      "--url 'revisium://cloud.revisium.io' --credential 'default' --api-key",
     );
   });
 

--- a/src/commands/auth/__tests__/auth-login.command.spec.ts
+++ b/src/commands/auth/__tests__/auth-login.command.spec.ts
@@ -116,4 +116,16 @@ describe('AuthLoginCommand', () => {
       }),
     ).rejects.toThrow('Use only one credential input');
   });
+
+  it('parses command options', () => {
+    expect(command.parseUrl('revisium://cloud.revisium.io')).toBe(
+      'revisium://cloud.revisium.io',
+    );
+    expect(command.parseInstance('cloud')).toBe('cloud');
+    expect(command.parseCredential('admin')).toBe('admin');
+    expect(command.parseApiKey()).toBe(true);
+    expect(command.parseApiKeyStdin()).toBe(true);
+    expect(command.parseForce()).toBe(true);
+    expect(command.parseForce('false')).toBe(false);
+  });
 });

--- a/src/commands/auth/__tests__/auth-login.command.spec.ts
+++ b/src/commands/auth/__tests__/auth-login.command.spec.ts
@@ -1,0 +1,119 @@
+import { AuthLoginCommand } from '../auth-login.command';
+import {
+  CredentialStoreService,
+  CredentialTargetService,
+} from 'src/services/credentials';
+import { InteractiveService, LoggerService } from 'src/services/common';
+
+describe('AuthLoginCommand', () => {
+  let credentialTargets: { resolveRequired: jest.Mock };
+  let credentialStore: { saveApiKey: jest.Mock };
+  let interactive: { promptPassword: jest.Mock };
+  let logger: { success: jest.Mock };
+  let command: AuthLoginCommand;
+
+  beforeEach(() => {
+    credentialTargets = {
+      resolveRequired: jest.fn().mockResolvedValue({
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'admin',
+        instanceName: 'cloud',
+        authMode: 'stored',
+      }),
+    };
+    credentialStore = {
+      saveApiKey: jest.fn(),
+    };
+    interactive = {
+      promptPassword: jest.fn().mockResolvedValue(' rev_prompt '),
+    };
+    logger = {
+      success: jest.fn(),
+    };
+    command = new AuthLoginCommand(
+      credentialTargets as unknown as CredentialTargetService,
+      credentialStore as unknown as CredentialStoreService,
+      interactive as unknown as InteractiveService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  it('prompts for an API key and saves it for the resolved target', async () => {
+    await command.run([], {
+      instance: 'cloud',
+      credential: 'admin',
+      apiKey: true,
+    });
+
+    expect(interactive.promptPassword).toHaveBeenCalledWith(
+      'Enter Revisium API key:',
+    );
+    expect(credentialStore.saveApiKey).toHaveBeenCalledWith(
+      {
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'admin',
+      },
+      'rev_prompt',
+    );
+    expect(logger.success).toHaveBeenCalledWith(
+      'Saved API key credential "admin" for instance "cloud" (https://cloud.revisium.io)',
+    );
+  });
+
+  it('rejects authMode none targets unless force is set', async () => {
+    credentialTargets.resolveRequired.mockResolvedValue({
+      baseUrl: 'http://localhost:9222',
+      credential: 'default',
+      instanceName: 'local',
+      authMode: 'none',
+    });
+
+    await expect(
+      command.run([], {
+        instance: 'local',
+        apiKey: true,
+      }),
+    ).rejects.toThrow('uses authMode "none"');
+
+    expect(credentialStore.saveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('allows forced saves for authMode none targets', async () => {
+    credentialTargets.resolveRequired.mockResolvedValue({
+      baseUrl: 'http://localhost:9222',
+      credential: 'default',
+      instanceName: 'local',
+      authMode: 'none',
+    });
+
+    await command.run([], {
+      instance: 'local',
+      apiKey: true,
+      force: true,
+    });
+
+    expect(credentialStore.saveApiKey).toHaveBeenCalledWith(
+      {
+        baseUrl: 'http://localhost:9222',
+        credential: 'default',
+      },
+      'rev_prompt',
+    );
+  });
+
+  it('requires one API key input mode', async () => {
+    await expect(
+      command.run([], {
+        instance: 'cloud',
+      }),
+    ).rejects.toThrow('Pass --api-key to prompt, or --api-key-stdin');
+
+    await expect(
+      command.run([], {
+        instance: 'cloud',
+        apiKey: true,
+        apiKeyStdin: true,
+      }),
+    ).rejects.toThrow('Use only one credential input');
+  });
+});

--- a/src/commands/auth/__tests__/auth-logout.command.spec.ts
+++ b/src/commands/auth/__tests__/auth-logout.command.spec.ts
@@ -1,0 +1,85 @@
+import { AuthLogoutCommand } from '../auth-logout.command';
+import {
+  CredentialStoreService,
+  CredentialTargetService,
+} from 'src/services/credentials';
+import { LoggerService } from 'src/services/common';
+
+describe('AuthLogoutCommand', () => {
+  let credentialTargets: { resolveOrCurrentContext: jest.Mock };
+  let credentialStore: { deleteCredential: jest.Mock };
+  let logger: {
+    success: jest.Mock;
+    warn: jest.Mock;
+  };
+  let command: AuthLogoutCommand;
+
+  beforeEach(() => {
+    credentialTargets = {
+      resolveOrCurrentContext: jest.fn().mockResolvedValue({
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'admin',
+        instanceName: 'cloud',
+        authMode: 'stored',
+      }),
+    };
+    credentialStore = {
+      deleteCredential: jest.fn().mockReturnValue(true),
+    };
+    logger = {
+      success: jest.fn(),
+      warn: jest.fn(),
+    };
+    command = new AuthLogoutCommand(
+      credentialTargets as unknown as CredentialTargetService,
+      credentialStore as unknown as CredentialStoreService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  it('deletes a saved credential for the resolved target', async () => {
+    await command.run([], {
+      instance: 'cloud',
+      credential: 'admin',
+    });
+
+    expect(credentialTargets.resolveOrCurrentContext).toHaveBeenCalledWith({
+      instance: 'cloud',
+      credential: 'admin',
+    });
+    expect(credentialStore.deleteCredential).toHaveBeenCalledWith({
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'admin',
+    });
+    expect(logger.success).toHaveBeenCalledWith(
+      'Deleted saved credential "admin" for instance "cloud" (https://cloud.revisium.io)',
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when the resolved credential does not exist', async () => {
+    credentialTargets.resolveOrCurrentContext.mockResolvedValue({
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'default',
+      authMode: 'stored',
+    });
+    credentialStore.deleteCredential.mockReturnValue(false);
+
+    await command.run([], {
+      url: 'revisium://cloud.revisium.io',
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'No saved credential "default" found for https://cloud.revisium.io',
+    );
+    expect(logger.success).not.toHaveBeenCalled();
+  });
+
+  it('parses command options', () => {
+    expect(command.parseUrl('revisium://cloud.revisium.io')).toBe(
+      'revisium://cloud.revisium.io',
+    );
+    expect(command.parseInstance('cloud')).toBe('cloud');
+    expect(command.parseCredential('admin')).toBe('admin');
+  });
+});

--- a/src/commands/auth/__tests__/auth-status.command.spec.ts
+++ b/src/commands/auth/__tests__/auth-status.command.spec.ts
@@ -72,7 +72,7 @@ describe('AuthStatusCommand', () => {
     });
 
     expect(logger.warn).toHaveBeenCalledWith(
-      'No saved credential found. Run: revisium auth login --url revisium://cloud.revisium.io --credential default --api-key',
+      'No saved credential found. Run: revisium auth login --url "revisium://cloud.revisium.io" --credential "default" --api-key',
     );
   });
 

--- a/src/commands/auth/__tests__/auth-status.command.spec.ts
+++ b/src/commands/auth/__tests__/auth-status.command.spec.ts
@@ -1,0 +1,106 @@
+import { AuthStatusCommand } from '../auth-status.command';
+import {
+  CredentialStoreService,
+  CredentialTargetService,
+} from 'src/services/credentials';
+import { LoggerService } from 'src/services/common';
+
+describe('AuthStatusCommand', () => {
+  let credentialTargets: { resolveOrCurrentContext: jest.Mock };
+  let credentialStore: { hasCredential: jest.Mock };
+  let logger: {
+    info: jest.Mock;
+    success: jest.Mock;
+    warn: jest.Mock;
+  };
+  let command: AuthStatusCommand;
+
+  beforeEach(() => {
+    credentialTargets = {
+      resolveOrCurrentContext: jest.fn().mockResolvedValue({
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'admin',
+        instanceName: 'cloud',
+        contextName: 'dictionary',
+        authMode: 'stored',
+      }),
+    };
+    credentialStore = {
+      hasCredential: jest.fn().mockReturnValue(true),
+    };
+    logger = {
+      info: jest.fn(),
+      success: jest.fn(),
+      warn: jest.fn(),
+    };
+    command = new AuthStatusCommand(
+      credentialTargets as unknown as CredentialTargetService,
+      credentialStore as unknown as CredentialStoreService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  it('prints saved credential status for the current context', async () => {
+    await command.run([], {});
+
+    expect(credentialTargets.resolveOrCurrentContext).toHaveBeenCalledWith({});
+    expect(credentialStore.hasCredential).toHaveBeenCalledWith({
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'admin',
+    });
+    expect(logger.info).toHaveBeenCalledWith('Context: dictionary');
+    expect(logger.info).toHaveBeenCalledWith('Instance: cloud');
+    expect(logger.info).toHaveBeenCalledWith(
+      'Base URL: https://cloud.revisium.io',
+    );
+    expect(logger.info).toHaveBeenCalledWith('Credential: admin');
+    expect(logger.info).toHaveBeenCalledWith('Auth mode: stored');
+    expect(logger.success).toHaveBeenCalledWith('Saved credential found');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('prints a login hint when the target has no saved credential', async () => {
+    credentialTargets.resolveOrCurrentContext.mockResolvedValue({
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'default',
+      authMode: 'stored',
+    });
+    credentialStore.hasCredential.mockReturnValue(false);
+
+    await command.run([], {
+      url: 'revisium://cloud.revisium.io/admin/dictionary/master',
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'No saved credential found. Run: revisium auth login --url revisium://cloud.revisium.io --credential default --api-key',
+    );
+  });
+
+  it('does not read the credential store for authMode none targets', async () => {
+    credentialTargets.resolveOrCurrentContext.mockResolvedValue({
+      baseUrl: 'http://localhost:9222',
+      credential: 'default',
+      instanceName: 'local',
+      authMode: 'none',
+    });
+
+    await command.run([], {
+      instance: 'local',
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Saved credentials are bypassed for authMode "none".',
+    );
+    expect(credentialStore.hasCredential).not.toHaveBeenCalled();
+    expect(logger.success).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('parses command options', () => {
+    expect(command.parseUrl('revisium://cloud.revisium.io')).toBe(
+      'revisium://cloud.revisium.io',
+    );
+    expect(command.parseInstance('cloud')).toBe('cloud');
+    expect(command.parseCredential('admin')).toBe('admin');
+  });
+});

--- a/src/commands/auth/__tests__/auth-status.command.spec.ts
+++ b/src/commands/auth/__tests__/auth-status.command.spec.ts
@@ -72,7 +72,7 @@ describe('AuthStatusCommand', () => {
     });
 
     expect(logger.warn).toHaveBeenCalledWith(
-      'No saved credential found. Run: revisium auth login --url "revisium://cloud.revisium.io" --credential "default" --api-key',
+      "No saved credential found. Run: revisium auth login --url 'revisium://cloud.revisium.io' --credential 'default' --api-key",
     );
   });
 

--- a/src/commands/auth/__tests__/auth.command.spec.ts
+++ b/src/commands/auth/__tests__/auth.command.spec.ts
@@ -1,0 +1,18 @@
+import { AuthCommand } from '../auth.command';
+
+describe('AuthCommand', () => {
+  it('shows help when no auth subcommand is provided', async () => {
+    const command = new AuthCommand();
+    const help = jest.fn();
+
+    Object.assign(command, {
+      command: {
+        help,
+      },
+    });
+
+    await command.run();
+
+    expect(help).toHaveBeenCalled();
+  });
+});

--- a/src/commands/auth/auth-command.utils.ts
+++ b/src/commands/auth/auth-command.utils.ts
@@ -5,7 +5,8 @@ export interface AuthCommandTarget {
 }
 
 function quoteArg(value: string): string {
-  return JSON.stringify(value);
+  const escaped = value.replace(/'/g, `'\\''`);
+  return `'${escaped}'`;
 }
 
 export function formatAuthTarget(

--- a/src/commands/auth/auth-command.utils.ts
+++ b/src/commands/auth/auth-command.utils.ts
@@ -5,7 +5,10 @@ export interface AuthCommandTarget {
 }
 
 function quoteArg(value: string): string {
-  const escaped = value.replace(/'/g, `'\\''`);
+  if (process.platform === 'win32') {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+  const escaped = value.replaceAll("'", String.raw`'\''`);
   return `'${escaped}'`;
 }
 

--- a/src/commands/auth/auth-command.utils.ts
+++ b/src/commands/auth/auth-command.utils.ts
@@ -4,6 +4,10 @@ export interface AuthCommandTarget {
   credential: string;
 }
 
+function quoteArg(value: string): string {
+  return JSON.stringify(value);
+}
+
 export function formatAuthTarget(
   instanceName: string | undefined,
   baseUrl: string,
@@ -13,12 +17,16 @@ export function formatAuthTarget(
 
 export function formatAuthLoginHint(target: AuthCommandTarget): string {
   const targetSelector = target.instanceName
-    ? `--instance ${target.instanceName}`
-    : `--url ${formatAuthRevisiumUrl(target.baseUrl)}`;
+    ? `--instance ${quoteArg(target.instanceName)}`
+    : `--url ${quoteArg(formatAuthRevisiumUrl(target.baseUrl))}`;
 
-  return `${targetSelector} --credential ${target.credential} --api-key`;
+  return `${targetSelector} --credential ${quoteArg(target.credential)} --api-key`;
 }
 
 export function formatAuthRevisiumUrl(baseUrl: string): string {
-  return `revisium://${baseUrl.replace(/^https?:\/\//, '')}`;
+  if (baseUrl.startsWith('http://')) {
+    return `revisium+http://${baseUrl.slice('http://'.length)}`;
+  }
+
+  return `revisium://${baseUrl.replace(/^https:\/\//, '')}`;
 }

--- a/src/commands/auth/auth-command.utils.ts
+++ b/src/commands/auth/auth-command.utils.ts
@@ -1,0 +1,24 @@
+export interface AuthCommandTarget {
+  instanceName?: string;
+  baseUrl: string;
+  credential: string;
+}
+
+export function formatAuthTarget(
+  instanceName: string | undefined,
+  baseUrl: string,
+): string {
+  return instanceName ? `instance "${instanceName}" (${baseUrl})` : baseUrl;
+}
+
+export function formatAuthLoginHint(target: AuthCommandTarget): string {
+  const targetSelector = target.instanceName
+    ? `--instance ${target.instanceName}`
+    : `--url ${formatAuthRevisiumUrl(target.baseUrl)}`;
+
+  return `${targetSelector} --credential ${target.credential} --api-key`;
+}
+
+export function formatAuthRevisiumUrl(baseUrl: string): string {
+  return `revisium://${baseUrl.replace(/^https?:\/\//, '')}`;
+}

--- a/src/commands/auth/auth-login.command.ts
+++ b/src/commands/auth/auth-login.command.ts
@@ -5,6 +5,7 @@ import {
 } from 'src/services/credentials';
 import { InteractiveService, LoggerService } from 'src/services/common';
 import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+import { formatAuthTarget } from './auth-command.utils';
 
 interface Options {
   url?: string;
@@ -61,7 +62,7 @@ export class AuthLoginCommand extends CommandRunner {
     );
 
     this.logger.success(
-      `Saved API key credential "${target.credential}" for ${this.formatTarget(target.instanceName, target.baseUrl)}`,
+      `Saved API key credential "${target.credential}" for ${formatAuthTarget(target.instanceName, target.baseUrl)}`,
     );
   }
 
@@ -93,13 +94,6 @@ export class AuthLoginCommand extends CommandRunner {
       throw new Error('API key cannot be empty');
     }
     return apiKey;
-  }
-
-  private formatTarget(
-    instanceName: string | undefined,
-    baseUrl: string,
-  ): string {
-    return instanceName ? `instance "${instanceName}" (${baseUrl})` : baseUrl;
   }
 
   @Option({

--- a/src/commands/auth/auth-login.command.ts
+++ b/src/commands/auth/auth-login.command.ts
@@ -1,0 +1,152 @@
+import { CommandRunner, Option, SubCommand } from 'nest-commander';
+import {
+  CredentialStoreService,
+  CredentialTargetService,
+} from 'src/services/credentials';
+import { InteractiveService, LoggerService } from 'src/services/common';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+
+interface Options {
+  url?: string;
+  instance?: string;
+  credential?: string;
+  apiKey?: boolean;
+  apiKeyStdin?: boolean;
+  force?: boolean;
+}
+
+@SubCommand({
+  name: 'login',
+  description: 'Save an API key in the OS credential store',
+})
+export class AuthLoginCommand extends CommandRunner {
+  constructor(
+    private readonly credentialTargets: CredentialTargetService,
+    private readonly credentialStore: CredentialStoreService,
+    private readonly interactive: InteractiveService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(_inputs: string[], options: Options): Promise<void> {
+    if (options.apiKey && options.apiKeyStdin) {
+      throw new Error(
+        'Use only one credential input: --api-key or --api-key-stdin',
+      );
+    }
+    if (!options.apiKey && !options.apiKeyStdin) {
+      throw new Error(
+        'Pass --api-key to prompt, or --api-key-stdin for scripts',
+      );
+    }
+
+    const target = await this.credentialTargets.resolveRequired(options);
+    if (target.authMode === 'none' && !options.force) {
+      throw new Error(
+        `Instance "${target.instanceName || target.baseUrl}" uses authMode "none". Pass --force to save credentials anyway.`,
+      );
+    }
+
+    const apiKey = options.apiKeyStdin
+      ? await this.readApiKeyFromStdin()
+      : await this.promptForApiKey();
+
+    this.credentialStore.saveApiKey(
+      {
+        baseUrl: target.baseUrl,
+        credential: target.credential,
+      },
+      apiKey,
+    );
+
+    this.logger.success(
+      `Saved API key credential "${target.credential}" for ${this.formatTarget(target.instanceName, target.baseUrl)}`,
+    );
+  }
+
+  private async promptForApiKey(): Promise<string> {
+    const apiKey = await this.interactive.promptPassword(
+      'Enter Revisium API key:',
+    );
+    return this.validateApiKey(apiKey);
+  }
+
+  private async readApiKeyFromStdin(): Promise<string> {
+    const chunks: Buffer[] = [];
+
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+      if (Buffer.concat(chunks).includes(10)) {
+        break;
+      }
+    }
+
+    return this.validateApiKey(
+      Buffer.concat(chunks).toString('utf-8').split(/\r?\n/, 1)[0],
+    );
+  }
+
+  private validateApiKey(value: string | undefined): string {
+    const apiKey = value?.trim();
+    if (!apiKey) {
+      throw new Error('API key cannot be empty');
+    }
+    return apiKey;
+  }
+
+  private formatTarget(
+    instanceName: string | undefined,
+    baseUrl: string,
+  ): string {
+    return instanceName ? `instance "${instanceName}" (${baseUrl})` : baseUrl;
+  }
+
+  @Option({
+    flags: '--url <url>',
+    description: 'Revisium server or target URL',
+  })
+  parseUrl(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--instance <name>',
+    description: 'Instance name from workspace config',
+  })
+  parseInstance(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--credential <name>',
+    description: 'Credential name (default: default)',
+  })
+  parseCredential(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--api-key',
+    description: 'Prompt for an API key and save it',
+  })
+  parseApiKey(): boolean {
+    return true;
+  }
+
+  @Option({
+    flags: '--api-key-stdin',
+    description: 'Read one API key line from stdin and save it',
+  })
+  parseApiKeyStdin(): boolean {
+    return true;
+  }
+
+  @Option({
+    flags: '--force [boolean]',
+    description: 'Allow saving credentials for an authMode none instance',
+  })
+  parseForce(value?: string): boolean {
+    return parseBooleanOption(value);
+  }
+}

--- a/src/commands/auth/auth-logout.command.ts
+++ b/src/commands/auth/auth-logout.command.ts
@@ -1,0 +1,77 @@
+import { CommandRunner, Option, SubCommand } from 'nest-commander';
+import {
+  CredentialStoreService,
+  CredentialTargetService,
+} from 'src/services/credentials';
+import { LoggerService } from 'src/services/common';
+
+interface Options {
+  url?: string;
+  instance?: string;
+  credential?: string;
+}
+
+@SubCommand({
+  name: 'logout',
+  description: 'Delete a saved Revisium credential',
+})
+export class AuthLogoutCommand extends CommandRunner {
+  constructor(
+    private readonly credentialTargets: CredentialTargetService,
+    private readonly credentialStore: CredentialStoreService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(_inputs: string[], options: Options): Promise<void> {
+    const target =
+      await this.credentialTargets.resolveOrCurrentContext(options);
+    const deleted = this.credentialStore.deleteCredential({
+      baseUrl: target.baseUrl,
+      credential: target.credential,
+    });
+
+    if (deleted) {
+      this.logger.success(
+        `Deleted saved credential "${target.credential}" for ${this.formatTarget(target.instanceName, target.baseUrl)}`,
+      );
+      return;
+    }
+
+    this.logger.warn(
+      `No saved credential "${target.credential}" found for ${this.formatTarget(target.instanceName, target.baseUrl)}`,
+    );
+  }
+
+  private formatTarget(
+    instanceName: string | undefined,
+    baseUrl: string,
+  ): string {
+    return instanceName ? `instance "${instanceName}" (${baseUrl})` : baseUrl;
+  }
+
+  @Option({
+    flags: '--url <url>',
+    description: 'Revisium server or target URL',
+  })
+  parseUrl(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--instance <name>',
+    description: 'Instance name from workspace config',
+  })
+  parseInstance(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--credential <name>',
+    description: 'Credential name',
+  })
+  parseCredential(value: string) {
+    return value;
+  }
+}

--- a/src/commands/auth/auth-logout.command.ts
+++ b/src/commands/auth/auth-logout.command.ts
@@ -4,6 +4,7 @@ import {
   CredentialTargetService,
 } from 'src/services/credentials';
 import { LoggerService } from 'src/services/common';
+import { formatAuthTarget } from './auth-command.utils';
 
 interface Options {
   url?: string;
@@ -34,21 +35,14 @@ export class AuthLogoutCommand extends CommandRunner {
 
     if (deleted) {
       this.logger.success(
-        `Deleted saved credential "${target.credential}" for ${this.formatTarget(target.instanceName, target.baseUrl)}`,
+        `Deleted saved credential "${target.credential}" for ${formatAuthTarget(target.instanceName, target.baseUrl)}`,
       );
       return;
     }
 
     this.logger.warn(
-      `No saved credential "${target.credential}" found for ${this.formatTarget(target.instanceName, target.baseUrl)}`,
+      `No saved credential "${target.credential}" found for ${formatAuthTarget(target.instanceName, target.baseUrl)}`,
     );
-  }
-
-  private formatTarget(
-    instanceName: string | undefined,
-    baseUrl: string,
-  ): string {
-    return instanceName ? `instance "${instanceName}" (${baseUrl})` : baseUrl;
   }
 
   @Option({

--- a/src/commands/auth/auth-status.command.ts
+++ b/src/commands/auth/auth-status.command.ts
@@ -1,0 +1,97 @@
+import { CommandRunner, Option, SubCommand } from 'nest-commander';
+import {
+  CredentialStoreService,
+  CredentialTargetService,
+} from 'src/services/credentials';
+import { LoggerService } from 'src/services/common';
+
+interface Options {
+  url?: string;
+  instance?: string;
+  credential?: string;
+}
+
+@SubCommand({
+  name: 'status',
+  description: 'Show saved Revisium credential status',
+})
+export class AuthStatusCommand extends CommandRunner {
+  constructor(
+    private readonly credentialTargets: CredentialTargetService,
+    private readonly credentialStore: CredentialStoreService,
+    private readonly logger: LoggerService,
+  ) {
+    super();
+  }
+
+  async run(_inputs: string[], options: Options): Promise<void> {
+    const target =
+      await this.credentialTargets.resolveOrCurrentContext(options);
+    const ref = {
+      baseUrl: target.baseUrl,
+      credential: target.credential,
+    };
+    const hasCredential = this.credentialStore.hasCredential(ref);
+
+    if (target.contextName) {
+      this.logger.info(`Context: ${target.contextName}`);
+    }
+    if (target.instanceName) {
+      this.logger.info(`Instance: ${target.instanceName}`);
+    }
+    this.logger.info(`Base URL: ${target.baseUrl}`);
+    this.logger.info(`Credential: ${target.credential}`);
+    this.logger.info(`Auth mode: ${target.authMode || 'stored'}`);
+
+    if ((target.authMode || 'stored') === 'none') {
+      this.logger.info('Saved credentials are bypassed for authMode "none".');
+    }
+
+    if (hasCredential) {
+      this.logger.success('Saved credential found');
+      this.logger.info(
+        'API key identity verification is limited until auth principal introspection is available.',
+      );
+      return;
+    }
+
+    this.logger.warn(
+      `No saved credential found. Run: revisium auth login ${this.formatLoginHint(target)}`,
+    );
+  }
+
+  private formatLoginHint(target: {
+    instanceName?: string;
+    baseUrl: string;
+    credential: string;
+  }): string {
+    const targetSelector = target.instanceName
+      ? `--instance ${target.instanceName}`
+      : `--url revisium://${target.baseUrl.replace(/^https?:\/\//, '')}`;
+    return `${targetSelector} --credential ${target.credential} --api-key`;
+  }
+
+  @Option({
+    flags: '--url <url>',
+    description: 'Revisium server or target URL',
+  })
+  parseUrl(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--instance <name>',
+    description: 'Instance name from workspace config',
+  })
+  parseInstance(value: string) {
+    return value;
+  }
+
+  @Option({
+    flags: '--credential <name>',
+    description: 'Credential name',
+  })
+  parseCredential(value: string) {
+    return value;
+  }
+}

--- a/src/commands/auth/auth-status.command.ts
+++ b/src/commands/auth/auth-status.command.ts
@@ -4,6 +4,7 @@ import {
   CredentialTargetService,
 } from 'src/services/credentials';
 import { LoggerService } from 'src/services/common';
+import { formatAuthLoginHint } from './auth-command.utils';
 
 interface Options {
   url?: string;
@@ -31,7 +32,6 @@ export class AuthStatusCommand extends CommandRunner {
       baseUrl: target.baseUrl,
       credential: target.credential,
     };
-    const hasCredential = this.credentialStore.hasCredential(ref);
 
     if (target.contextName) {
       this.logger.info(`Context: ${target.contextName}`);
@@ -45,7 +45,10 @@ export class AuthStatusCommand extends CommandRunner {
 
     if ((target.authMode || 'stored') === 'none') {
       this.logger.info('Saved credentials are bypassed for authMode "none".');
+      return;
     }
+
+    const hasCredential = this.credentialStore.hasCredential(ref);
 
     if (hasCredential) {
       this.logger.success('Saved credential found');
@@ -56,19 +59,8 @@ export class AuthStatusCommand extends CommandRunner {
     }
 
     this.logger.warn(
-      `No saved credential found. Run: revisium auth login ${this.formatLoginHint(target)}`,
+      `No saved credential found. Run: revisium auth login ${formatAuthLoginHint(target)}`,
     );
-  }
-
-  private formatLoginHint(target: {
-    instanceName?: string;
-    baseUrl: string;
-    credential: string;
-  }): string {
-    const targetSelector = target.instanceName
-      ? `--instance ${target.instanceName}`
-      : `--url revisium://${target.baseUrl.replace(/^https?:\/\//, '')}`;
-    return `${targetSelector} --credential ${target.credential} --api-key`;
   }
 
   @Option({

--- a/src/commands/auth/auth.command.ts
+++ b/src/commands/auth/auth.command.ts
@@ -1,0 +1,20 @@
+import { Command, CommandRunner } from 'nest-commander';
+import { AuthLoginCommand } from './auth-login.command';
+import { AuthLogoutCommand } from './auth-logout.command';
+import { AuthStatusCommand } from './auth-status.command';
+
+@Command({
+  name: 'auth',
+  description: 'Manage saved Revisium credentials',
+  subCommands: [AuthLoginCommand, AuthStatusCommand, AuthLogoutCommand],
+})
+export class AuthCommand extends CommandRunner {
+  constructor() {
+    super();
+  }
+
+  run(): Promise<void> {
+    this.command.help();
+    return Promise.resolve();
+  }
+}

--- a/src/services/credentials/__tests__/credential-store.service.spec.ts
+++ b/src/services/credentials/__tests__/credential-store.service.spec.ts
@@ -7,12 +7,30 @@ jest.mock('@napi-rs/keyring', () => ({
     setPassword: jest.fn((password: string) => {
       keyringEntries.set(`${service}:${account}`, password);
     }),
-    getPassword: jest.fn(
-      () => keyringEntries.get(`${service}:${account}`) ?? null,
-    ),
-    deleteCredential: jest.fn(() =>
-      keyringEntries.delete(`${service}:${account}`),
-    ),
+    getPassword: jest.fn(() => {
+      if (account.includes('credential:missing-code')) {
+        const error = new Error('mock missing credential');
+        Object.assign(error, { code: 'NoEntry' });
+        throw error;
+      }
+
+      if (account.includes('credential:missing-name')) {
+        const error = new Error('mock missing credential');
+        error.name = 'NoEntry';
+        throw error;
+      }
+
+      return keyringEntries.get(`${service}:${account}`) ?? null;
+    }),
+    deleteCredential: jest.fn(() => {
+      if (account.includes('credential:missing-code')) {
+        const error = new Error('mock missing credential');
+        Object.assign(error, { code: 'NoEntry' });
+        throw error;
+      }
+
+      return keyringEntries.delete(`${service}:${account}`);
+    }),
   })),
 }));
 
@@ -85,5 +103,26 @@ describe('CredentialStoreService', () => {
     expect(() => service.getCredential(ref)).toThrow(
       'Saved Revisium credential "default" for https://cloud.revisium.io has an unsupported format',
     );
+  });
+
+  it('treats keyring NoEntry errors as missing credentials', () => {
+    expect(
+      service.getCredential({
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'missing-code',
+      }),
+    ).toBeUndefined();
+    expect(
+      service.getCredential({
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'missing-name',
+      }),
+    ).toBeUndefined();
+    expect(
+      service.deleteCredential({
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'missing-code',
+      }),
+    ).toBe(false);
   });
 });

--- a/src/services/credentials/__tests__/credential-store.service.spec.ts
+++ b/src/services/credentials/__tests__/credential-store.service.spec.ts
@@ -1,0 +1,89 @@
+import { CredentialStoreService } from '../credential-store.service';
+
+const keyringEntries = new Map<string, string>();
+
+jest.mock('@napi-rs/keyring', () => ({
+  Entry: jest.fn().mockImplementation((service: string, account: string) => ({
+    setPassword: jest.fn((password: string) => {
+      keyringEntries.set(`${service}:${account}`, password);
+    }),
+    getPassword: jest.fn(
+      () => keyringEntries.get(`${service}:${account}`) ?? null,
+    ),
+    deleteCredential: jest.fn(() =>
+      keyringEntries.delete(`${service}:${account}`),
+    ),
+  })),
+}));
+
+describe('CredentialStoreService', () => {
+  let service: CredentialStoreService;
+  const originalServiceName = process.env.REVISIUM_CREDENTIAL_STORE_SERVICE;
+
+  beforeEach(() => {
+    delete process.env.REVISIUM_CREDENTIAL_STORE_SERVICE;
+    keyringEntries.clear();
+    service = new CredentialStoreService();
+  });
+
+  afterAll(() => {
+    if (originalServiceName === undefined) {
+      delete process.env.REVISIUM_CREDENTIAL_STORE_SERVICE;
+      return;
+    }
+    process.env.REVISIUM_CREDENTIAL_STORE_SERVICE = originalServiceName;
+  });
+
+  it('saves, reads, and deletes API key credentials by base URL and credential name', () => {
+    const ref = {
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'admin',
+    };
+
+    service.saveApiKey(ref, ' rev_saved ');
+
+    expect(service.hasCredential(ref)).toBe(true);
+    expect(service.getCredential(ref)).toEqual({
+      method: 'apikey',
+      apikey: 'rev_saved',
+    });
+    expect(service.deleteCredential(ref)).toBe(true);
+    expect(service.getCredential(ref)).toBeUndefined();
+  });
+
+  it('uses normalized base URL and credential name in the account key', () => {
+    expect(
+      service.getAccountName({
+        baseUrl: 'https://cloud.revisium.io',
+        credential: 'admin',
+      }),
+    ).toBe('instance:https://cloud.revisium.io|credential:admin');
+  });
+
+  it('rejects empty API keys before writing to the store', () => {
+    expect(() =>
+      service.saveApiKey(
+        {
+          baseUrl: 'https://cloud.revisium.io',
+          credential: 'default',
+        },
+        ' ',
+      ),
+    ).toThrow('API key cannot be empty');
+  });
+
+  it('fails clearly when a saved credential has unsupported JSON', () => {
+    const ref = {
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'default',
+    };
+    keyringEntries.set(
+      `revisium-cli:${service.getAccountName(ref)}`,
+      JSON.stringify({ method: 'token', token: 'jwt' }),
+    );
+
+    expect(() => service.getCredential(ref)).toThrow(
+      'Saved Revisium credential "default" for https://cloud.revisium.io has an unsupported format',
+    );
+  });
+});

--- a/src/services/credentials/__tests__/credential-target.service.spec.ts
+++ b/src/services/credentials/__tests__/credential-target.service.spec.ts
@@ -1,0 +1,126 @@
+import { CredentialTargetService } from '../credential-target.service';
+import { WorkspaceConfigService } from '../../workspace';
+
+describe('CredentialTargetService', () => {
+  let workspaceConfig: {
+    load: jest.Mock;
+    normalizeBaseUrl: jest.Mock;
+    findInstanceNameByBaseUrl: jest.Mock;
+  };
+  let service: CredentialTargetService;
+
+  beforeEach(() => {
+    workspaceConfig = {
+      load: jest.fn(),
+      normalizeBaseUrl: jest.fn(),
+      findInstanceNameByBaseUrl: jest.fn(),
+    };
+    service = new CredentialTargetService(
+      workspaceConfig as unknown as WorkspaceConfigService,
+    );
+  });
+
+  it('resolves explicit instance targets from workspace config', async () => {
+    workspaceConfig.load.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: {
+        version: 1,
+        currentContext: 'dictionary',
+        instances: {
+          cloud: {
+            baseUrl: 'https://cloud.revisium.io',
+            authMode: 'stored',
+          },
+        },
+        contexts: {},
+      },
+    });
+
+    await expect(
+      service.resolveRequired({
+        instance: 'cloud',
+        credential: 'admin',
+      }),
+    ).resolves.toEqual({
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'admin',
+      instanceName: 'cloud',
+      authMode: 'stored',
+      configPath: '/repo/.revisium/revisium-cli.config.json',
+    });
+  });
+
+  it('resolves URL targets and attaches matching instance metadata when available', async () => {
+    workspaceConfig.normalizeBaseUrl.mockReturnValue(
+      'https://cloud.revisium.io',
+    );
+    workspaceConfig.findInstanceNameByBaseUrl.mockReturnValue('cloud');
+    workspaceConfig.load.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: {
+        version: 1,
+        instances: {
+          cloud: {
+            baseUrl: 'https://cloud.revisium.io',
+            authMode: 'none',
+          },
+        },
+        contexts: {},
+      },
+    });
+
+    await expect(
+      service.resolveRequired({
+        url: 'revisium://cloud.revisium.io/admin/dictionary/master',
+      }),
+    ).resolves.toEqual({
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'default',
+      instanceName: 'cloud',
+      authMode: 'none',
+      configPath: '/repo/.revisium/revisium-cli.config.json',
+    });
+  });
+
+  it('uses the current context when status/logout omit target selectors', async () => {
+    workspaceConfig.load.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: {
+        version: 1,
+        currentContext: 'dictionary',
+        instances: {
+          cloud: {
+            baseUrl: 'https://cloud.revisium.io',
+            authMode: 'stored',
+          },
+        },
+        contexts: {
+          dictionary: {
+            instance: 'cloud',
+            credential: 'admin',
+            organization: 'admin',
+            project: 'dictionary',
+          },
+        },
+      },
+    });
+
+    await expect(service.resolveOrCurrentContext({})).resolves.toEqual({
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'admin',
+      instanceName: 'cloud',
+      contextName: 'dictionary',
+      authMode: 'stored',
+      configPath: '/repo/.revisium/revisium-cli.config.json',
+    });
+  });
+
+  it('rejects ambiguous target selectors', async () => {
+    await expect(
+      service.resolveRequired({
+        url: 'revisium://cloud.revisium.io',
+        instance: 'cloud',
+      }),
+    ).rejects.toThrow('Use only one target selector: --instance or --url');
+  });
+});

--- a/src/services/credentials/credential-store.service.ts
+++ b/src/services/credentials/credential-store.service.ts
@@ -119,11 +119,16 @@ export class CredentialStoreService {
   }
 
   private isMissingCredentialError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+      return false;
+    }
+
+    const keyringError = error as Error & { code?: unknown };
+
     return (
-      error instanceof Error &&
-      (error.message.includes('NoEntry') ||
-        error.message.includes('not found') ||
-        error.message.includes('No matching entry'))
+      keyringError.code === 'NoEntry' ||
+      error.name === 'NoEntry' ||
+      error.message.includes('NoEntry')
     );
   }
 

--- a/src/services/credentials/credential-store.service.ts
+++ b/src/services/credentials/credential-store.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { Entry } from '@napi-rs/keyring';
+import { AuthCredentials } from 'src/services/url';
+
+const SERVICE_NAME = 'revisium-cli';
+
+export interface CredentialRef {
+  baseUrl: string;
+  credential: string;
+}
+
+interface StoredApiKeyCredential {
+  method: 'apikey';
+  apiKey: string;
+}
+
+type StoredCredential = StoredApiKeyCredential;
+
+@Injectable()
+export class CredentialStoreService {
+  private readonly serviceName =
+    process.env.REVISIUM_CREDENTIAL_STORE_SERVICE || SERVICE_NAME;
+
+  saveApiKey(ref: CredentialRef, apiKey: string): void {
+    const trimmedApiKey = apiKey.trim();
+    if (!trimmedApiKey) {
+      throw new Error('API key cannot be empty');
+    }
+
+    this.writeCredential(ref, {
+      method: 'apikey',
+      apiKey: trimmedApiKey,
+    });
+  }
+
+  getCredential(ref: CredentialRef): AuthCredentials | undefined {
+    const raw = this.readCredential(ref);
+    if (!raw) {
+      return undefined;
+    }
+
+    const stored = this.parseStoredCredential(raw, ref);
+    return { method: 'apikey', apikey: stored.apiKey };
+  }
+
+  hasCredential(ref: CredentialRef): boolean {
+    return this.readCredential(ref) !== undefined;
+  }
+
+  deleteCredential(ref: CredentialRef): boolean {
+    try {
+      return this.createEntry(ref).deleteCredential();
+    } catch (error) {
+      if (this.isMissingCredentialError(error)) {
+        return false;
+      }
+      throw this.wrapStoreError('delete', ref, error);
+    }
+  }
+
+  getAccountName(ref: CredentialRef): string {
+    return `instance:${ref.baseUrl}|credential:${ref.credential}`;
+  }
+
+  private writeCredential(ref: CredentialRef, credential: StoredCredential) {
+    try {
+      this.createEntry(ref).setPassword(JSON.stringify(credential));
+    } catch (error) {
+      throw this.wrapStoreError('save', ref, error);
+    }
+  }
+
+  private readCredential(ref: CredentialRef): string | undefined {
+    try {
+      return this.createEntry(ref).getPassword() ?? undefined;
+    } catch (error) {
+      if (this.isMissingCredentialError(error)) {
+        return undefined;
+      }
+      throw this.wrapStoreError('read', ref, error);
+    }
+  }
+
+  private createEntry(ref: CredentialRef): Entry {
+    return new Entry(this.serviceName, this.getAccountName(ref));
+  }
+
+  private parseStoredCredential(
+    raw: string,
+    ref: CredentialRef,
+  ): StoredCredential {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error(
+        `Saved Revisium credential "${ref.credential}" for ${ref.baseUrl} is invalid. Run: revisium auth login --url revisium://${ref.baseUrl.replace(/^https?:\/\//, '')} --credential ${ref.credential} --api-key`,
+      );
+    }
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('method' in parsed) ||
+      parsed.method !== 'apikey' ||
+      !('apiKey' in parsed) ||
+      typeof parsed.apiKey !== 'string' ||
+      parsed.apiKey.trim() === ''
+    ) {
+      throw new Error(
+        `Saved Revisium credential "${ref.credential}" for ${ref.baseUrl} has an unsupported format. Run: revisium auth login --url revisium://${ref.baseUrl.replace(/^https?:\/\//, '')} --credential ${ref.credential} --api-key`,
+      );
+    }
+
+    return {
+      method: 'apikey',
+      apiKey: parsed.apiKey.trim(),
+    };
+  }
+
+  private isMissingCredentialError(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      (error.message.includes('NoEntry') ||
+        error.message.includes('not found') ||
+        error.message.includes('No matching entry'))
+    );
+  }
+
+  private wrapStoreError(
+    action: 'save' | 'read' | 'delete',
+    ref: CredentialRef,
+    error: unknown,
+  ): Error {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Error(
+      `Could not ${action} Revisium credential "${ref.credential}" for ${ref.baseUrl}: ${message}`,
+    );
+  }
+}

--- a/src/services/credentials/credential-target.service.ts
+++ b/src/services/credentials/credential-target.service.ts
@@ -1,0 +1,145 @@
+import { Injectable } from '@nestjs/common';
+import {
+  DEFAULT_CREDENTIAL,
+  WorkspaceAuthMode,
+  WorkspaceConfigService,
+} from 'src/services/workspace';
+
+export interface CredentialTargetOptions {
+  url?: string;
+  instance?: string;
+  credential?: string;
+}
+
+export interface CredentialTarget {
+  baseUrl: string;
+  credential: string;
+  instanceName?: string;
+  contextName?: string;
+  authMode?: WorkspaceAuthMode;
+  configPath?: string;
+}
+
+@Injectable()
+export class CredentialTargetService {
+  constructor(private readonly workspaceConfig: WorkspaceConfigService) {}
+
+  async resolveRequired(
+    options: CredentialTargetOptions,
+  ): Promise<CredentialTarget> {
+    if (!options.url && !options.instance) {
+      throw new Error('Pass --instance <name> or --url <revisium-url>');
+    }
+
+    return this.resolve(options, false);
+  }
+
+  async resolveOrCurrentContext(
+    options: CredentialTargetOptions,
+  ): Promise<CredentialTarget> {
+    return this.resolve(options, true);
+  }
+
+  private async resolve(
+    options: CredentialTargetOptions,
+    allowCurrentContext: boolean,
+  ): Promise<CredentialTarget> {
+    if (options.url && options.instance) {
+      throw new Error('Use only one target selector: --instance or --url');
+    }
+
+    if (options.url) {
+      return this.resolveUrlTarget(options);
+    }
+
+    const loaded = await this.workspaceConfig.load();
+    if (!loaded) {
+      throw new Error(
+        'No Revisium workspace config found. Pass --url <revisium-url> or run revisium instance add first.',
+      );
+    }
+
+    if (options.instance) {
+      const instance = loaded.config.instances[options.instance];
+      if (!instance) {
+        throw new Error(
+          `Revisium instance "${options.instance}" was not found`,
+        );
+      }
+
+      return {
+        baseUrl: instance.baseUrl,
+        credential: options.credential || DEFAULT_CREDENTIAL,
+        instanceName: options.instance,
+        authMode: instance.authMode || 'stored',
+        configPath: loaded.path,
+      };
+    }
+
+    if (!allowCurrentContext) {
+      throw new Error('Pass --instance <name> or --url <revisium-url>');
+    }
+
+    const contextName = loaded.config.currentContext;
+    if (!contextName) {
+      throw new Error(
+        `No current Revisium context is configured in ${loaded.path}. Run: revisium context use <name>`,
+      );
+    }
+
+    const context = loaded.config.contexts[contextName];
+    if (!context) {
+      throw new Error(`Revisium context "${contextName}" was not found`);
+    }
+
+    const instance = loaded.config.instances[context.instance];
+    if (!instance) {
+      throw new Error(
+        `Revisium instance "${context.instance}" for context "${contextName}" was not found`,
+      );
+    }
+
+    return {
+      baseUrl: instance.baseUrl,
+      credential:
+        options.credential || context.credential || DEFAULT_CREDENTIAL,
+      instanceName: context.instance,
+      contextName,
+      authMode: instance.authMode || 'stored',
+      configPath: loaded.path,
+    };
+  }
+
+  private async resolveUrlTarget(
+    options: CredentialTargetOptions,
+  ): Promise<CredentialTarget> {
+    if (!options.url) {
+      throw new Error('Pass --url <revisium-url>');
+    }
+
+    const baseUrl = this.workspaceConfig.normalizeBaseUrl(options.url);
+    const loaded = await this.workspaceConfig.load();
+    if (!loaded) {
+      return {
+        baseUrl,
+        credential: options.credential || DEFAULT_CREDENTIAL,
+      };
+    }
+
+    const instanceName = this.workspaceConfig.findInstanceNameByBaseUrl(
+      loaded.config,
+      baseUrl,
+    );
+    const instance = instanceName
+      ? loaded.config.instances[instanceName]
+      : undefined;
+
+    return {
+      baseUrl,
+      credential: options.credential || DEFAULT_CREDENTIAL,
+      instanceName,
+      authMode: instance?.authMode || 'stored',
+      configPath: loaded.path,
+    };
+  }
+}

--- a/src/services/credentials/index.ts
+++ b/src/services/credentials/index.ts
@@ -1,0 +1,9 @@
+export {
+  CredentialRef,
+  CredentialStoreService,
+} from './credential-store.service';
+export {
+  CredentialTarget,
+  CredentialTargetOptions,
+  CredentialTargetService,
+} from './credential-target.service';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,3 +3,4 @@ export * from './url';
 export * from './sync';
 export * from './common';
 export * from './workspace';
+export * from './credentials';

--- a/src/services/workspace/__tests__/workspace-config.service.spec.ts
+++ b/src/services/workspace/__tests__/workspace-config.service.spec.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { WorkspaceConfigService } from '../workspace-config.service';
 import { UrlParserService } from '../../url/url-parser.service';
+import { CredentialStoreService } from '../../credentials';
 
 describe('WorkspaceConfigService', () => {
   let service: WorkspaceConfigService;
@@ -159,6 +160,133 @@ describe('WorkspaceConfigService', () => {
     expect(url.auth).toEqual({ method: 'apikey', apikey: 'rev_test' });
   });
 
+  it('resolves saved credentials for stored workspace contexts', () => {
+    const credentialStore = {
+      getCredential: jest
+        .fn()
+        .mockReturnValue({ method: 'apikey', apikey: 'rev_saved' }),
+    } as unknown as CredentialStoreService;
+    service = new WorkspaceConfigService(
+      new UrlParserService(),
+      credentialStore,
+    );
+
+    const url = service.resolveConnection(
+      {
+        path: join(tempDir, '.revisium', 'revisium-cli.config.json'),
+        config: {
+          version: 1,
+          currentContext: 'cloud',
+          instances: {
+            cloud: {
+              baseUrl: 'https://cloud.revisium.io',
+              authMode: 'stored',
+            },
+          },
+          contexts: {
+            cloud: {
+              instance: 'cloud',
+              credential: 'admin',
+              organization: 'admin',
+              project: 'dictionary',
+            },
+          },
+        },
+      },
+      undefined,
+      {},
+    );
+
+    expect(url.auth).toEqual({ method: 'apikey', apikey: 'rev_saved' });
+    expect(credentialStore.getCredential).toHaveBeenCalledWith({
+      baseUrl: 'https://cloud.revisium.io',
+      credential: 'admin',
+    });
+  });
+
+  it('lets environment credentials override saved credentials', () => {
+    const credentialStore = {
+      getCredential: jest.fn(),
+    } as unknown as CredentialStoreService;
+    service = new WorkspaceConfigService(
+      new UrlParserService(),
+      credentialStore,
+    );
+
+    const url = service.resolveConnection(
+      {
+        path: join(tempDir, '.revisium', 'revisium-cli.config.json'),
+        config: {
+          version: 1,
+          currentContext: 'cloud',
+          instances: {
+            cloud: {
+              baseUrl: 'https://cloud.revisium.io',
+              authMode: 'stored',
+            },
+          },
+          contexts: {
+            cloud: {
+              instance: 'cloud',
+              credential: 'admin',
+              organization: 'admin',
+              project: 'dictionary',
+            },
+          },
+        },
+      },
+      undefined,
+      { apikey: 'rev_env' },
+    );
+
+    expect(url.auth).toEqual({ method: 'apikey', apikey: 'rev_env' });
+    expect(credentialStore.getCredential).not.toHaveBeenCalled();
+  });
+
+  it('fails with remediation when stored credentials cannot be read', () => {
+    const credentialStore = {
+      getCredential: jest.fn(() => {
+        throw new Error(
+          'Could not read Revisium credential "admin" for https://cloud.revisium.io: keyring unavailable',
+        );
+      }),
+    } as unknown as CredentialStoreService;
+    service = new WorkspaceConfigService(
+      new UrlParserService(),
+      credentialStore,
+    );
+
+    expect(() =>
+      service.resolveConnection(
+        {
+          path: join(tempDir, '.revisium', 'revisium-cli.config.json'),
+          config: {
+            version: 1,
+            currentContext: 'cloud',
+            instances: {
+              cloud: {
+                baseUrl: 'https://cloud.revisium.io',
+                authMode: 'stored',
+              },
+            },
+            contexts: {
+              cloud: {
+                instance: 'cloud',
+                credential: 'admin',
+                organization: 'admin',
+                project: 'dictionary',
+              },
+            },
+          },
+        },
+        undefined,
+        {},
+      ),
+    ).toThrow(
+      'No credentials found for context "cloud" credential "admin". Could not read the OS credential store',
+    );
+  });
+
   it('fails with remediation when stored credentials are required', () => {
     expect(() =>
       service.resolveConnection(
@@ -187,7 +315,7 @@ describe('WorkspaceConfigService', () => {
         {},
       ),
     ).toThrow(
-      'No credentials found for context "cloud" credential "admin". Set REVISIUM_API_KEY=...',
+      'No credentials found for context "cloud" credential "admin". Run: revisium auth login --instance cloud --credential admin --api-key.',
     );
   });
 

--- a/src/services/workspace/workspace-config.service.ts
+++ b/src/services/workspace/workspace-config.service.ts
@@ -1,11 +1,12 @@
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, parse, resolve } from 'node:path';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import {
   AuthCredentials,
   RevisiumUrlComplete,
   UrlEnvConfig,
 } from 'src/services/url';
+import { CredentialStoreService } from 'src/services/credentials/credential-store.service';
 import { UrlParserService } from 'src/services/url/url-parser.service';
 
 export const WORKSPACE_CONFIG_DIR = '.revisium';
@@ -49,7 +50,10 @@ export interface LoadedWorkspaceContext {
 
 @Injectable()
 export class WorkspaceConfigService {
-  constructor(private readonly urlParser: UrlParserService) {}
+  constructor(
+    private readonly urlParser: UrlParserService,
+    @Optional() private readonly credentialStore?: CredentialStoreService,
+  ) {}
 
   async load(
     startDir = process.cwd(),
@@ -244,10 +248,48 @@ export class WorkspaceConfigService {
     }
 
     const credential = context.credential || DEFAULT_CREDENTIAL;
+    const credentialRef = {
+      baseUrl: instance.baseUrl,
+      credential,
+    };
+    const savedCredential = this.resolveSavedCredential(
+      credentialRef,
+      contextName,
+      context.instance,
+    );
+    if (savedCredential) {
+      return savedCredential;
+    }
+
     throw new Error(
       `No credentials found for context "${contextName}" credential "${credential}". ` +
-        'Set REVISIUM_API_KEY=... or REVISIUM_TOKEN=..., or configure the instance with authMode "none" for local standalone.',
+        `Run: revisium auth login --instance ${context.instance} --credential ${credential} --api-key. ` +
+        'Or set REVISIUM_API_KEY=... / REVISIUM_TOKEN=..., or configure the instance with authMode "none" for local standalone.',
     );
+  }
+
+  private resolveSavedCredential(
+    ref: {
+      baseUrl: string;
+      credential: string;
+    },
+    contextName: string,
+    instanceName: string,
+  ): AuthCredentials | undefined {
+    try {
+      return this.credentialStore?.getCredential(ref);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.startsWith('Could not read Revisium credential')) {
+        throw new Error(
+          `No credentials found for context "${contextName}" credential "${ref.credential}". ` +
+            `Could not read the OS credential store: ${message}. ` +
+            `Run: revisium auth login --instance ${instanceName} --credential ${ref.credential} --api-key. ` +
+            'Or set REVISIUM_API_KEY=... / REVISIUM_TOKEN=... for this run.',
+        );
+      }
+      throw error;
+    }
   }
 
   private resolveEnvAuth(env: UrlEnvConfig): AuthCredentials | undefined {


### PR DESCRIPTION
## Summary
- add OS credential-store backed API-key storage using named credentials per normalized instance URL
- add revisium auth login/status/logout commands with --api-key and --api-key-stdin flows
- resolve stored workspace credentials after explicit/env auth and before prompting
- update auth/workspace docs and the auth bootstrap tracker

## Validation
- npm run tsc
- npm run lint:ci
- npm test -- --runInBand
- npm run build
- node dist/src/main.js auth login --help
- npm run test:e2e -- 07-workspace-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `auth` CLI group: `auth login`, `auth status`, `auth logout` to save, inspect, and remove API-key credentials stored in the OS credential store; login accepts interactive or stdin API-key input.
  * Workspace contexts can now use saved OS-stored API keys for authentication; auth precedence and workflows updated.

* **Documentation**
  * Expanded authentication and workspace docs with "Saved API Key" workflow, examples, env-var guidance, and updated command reference.

* **Tests**
  * Added comprehensive tests covering auth commands, credential store, and workspace auth behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-cli/pull/76)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->