### PR TITLE
ci: drop codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,3 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9 #SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Upload results to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 #codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Revisium CLI
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=revisium_revisium-cli&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=revisium_revisium-cli)
-[![codecov](https://codecov.io/gh/revisium/revisium-cli/branch/master/graph/badge.svg?token=8XI9VJ6EQR)](https://codecov.io/gh/revisium/revisium-cli)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=revisium_revisium-cli&metric=coverage)](https://sonarcloud.io/summary/new_code?id=revisium_revisium-cli)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=revisium_revisium-cli&metric=bugs)](https://sonarcloud.io/summary/new_code?id=revisium_revisium-cli)
 [![GitHub License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/revisium/revisium-cli/blob/master/LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/revisium/revisium-cli)](https://github.com/revisium/revisium-cli/releases)


### PR DESCRIPTION
Removes the Codecov upload step from CI and the README badge. Coverage is already reported by SonarCloud (`new_coverage` metric in the quality gate); the badge now points to the SonarCloud coverage measure instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality monitoring process, replacing Codecov with SonarQube for enhanced code analysis and coverage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->