### PR TITLE
test(e2e): cli matrix against fresh @revisium/standalone

### DIFF
--- a/e2e/jest-matrix.json
+++ b/e2e/jest-matrix.json
@@ -1,0 +1,14 @@
+{
+  "verbose": true,
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testEnvironment": "node",
+  "testRegex": "e2e/matrix/.*.e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "testTimeout": 600000,
+  "moduleDirectories": ["node_modules", "<rootDir>"],
+  "modulePaths": ["<rootDir>"],
+  "maxWorkers": 1
+}

--- a/e2e/jest-matrix.json
+++ b/e2e/jest-matrix.json
@@ -3,7 +3,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": "..",
   "testEnvironment": "node",
-  "testRegex": "e2e/matrix/.*.e2e-spec.ts$",
+  "testRegex": "e2e/matrix/.*\\.e2e-spec\\.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },

--- a/e2e/matrix/M01-auth-commands.e2e-spec.ts
+++ b/e2e/matrix/M01-auth-commands.e2e-spec.ts
@@ -127,12 +127,14 @@ describe('M01 — auth commands', () => {
       ['auth', 'status', '--instance', 'local', '--credential', 'automation'],
       { cwd: workspace, env },
     );
+    expect(automationStatus.exitCode).toBe(0);
     expect(automationStatus.stdout).toContain('Saved credential found');
 
     const defaultStatus = await runCli(
       ['auth', 'status', '--instance', 'local'],
       { cwd: workspace, env },
     );
+    expect(defaultStatus.exitCode).toBe(0);
     expect(defaultStatus.stdout).toContain('No saved credential found');
   });
 
@@ -187,11 +189,11 @@ describe('M01 — auth commands', () => {
     });
     const env = envWithStore();
 
-    await runCli(['auth', 'login', '--instance', 'local', '--api-key-stdin'], {
-      cwd: workspace,
-      env,
-      stdin: defaultApiKey + '\n',
-    });
+    const login = await runCli(
+      ['auth', 'login', '--instance', 'local', '--api-key-stdin'],
+      { cwd: workspace, env, stdin: defaultApiKey + '\n' },
+    );
+    expect(login.exitCode).toBe(0);
 
     const logout = await runCli(['auth', 'logout', '--instance', 'local'], {
       cwd: workspace,
@@ -203,6 +205,7 @@ describe('M01 — auth commands', () => {
       cwd: workspace,
       env,
     });
+    expect(status.exitCode).toBe(0);
     expect(status.stdout).toContain('No saved credential found');
   });
 
@@ -220,6 +223,7 @@ describe('M01 — auth commands', () => {
       cwd: workspace,
       env,
     });
+    expect(status.exitCode).toBe(0);
     expect(status.stdout).toContain('Saved credential found');
   });
 

--- a/e2e/matrix/M01-auth-commands.e2e-spec.ts
+++ b/e2e/matrix/M01-auth-commands.e2e-spec.ts
@@ -34,7 +34,6 @@ describe('M01 — auth commands', () => {
   let standalone: StandaloneInstance;
   let defaultApiKey: string;
   let automationApiKey: string;
-  let credentialStoreService: string;
   const workspaces: string[] = [];
 
   beforeAll(async () => {
@@ -49,13 +48,14 @@ describe('M01 — auth commands', () => {
     automationApiKey = (
       await standalone.api.mintApiKey('admin', { name: 'automation' })
     ).apiKey;
-    credentialStoreService = uniqueCredentialStoreService();
   }, 180_000);
 
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function newWorkspace(): string {
@@ -64,12 +64,14 @@ describe('M01 — auth commands', () => {
     return ws;
   }
 
+  /** Each test gets its own credential-store namespace so saved keys never
+   *  bleed between cases or with the developer's keyring. */
   function envWithStore(
     extra: Record<string, string> = {},
   ): Record<string, string> {
     return {
       ...CLEAR_REVISIUM_ENV,
-      REVISIUM_CREDENTIAL_STORE_SERVICE: credentialStoreService,
+      REVISIUM_CREDENTIAL_STORE_SERVICE: uniqueCredentialStoreService(),
       ...extra,
     };
   }

--- a/e2e/matrix/M01-auth-commands.e2e-spec.ts
+++ b/e2e/matrix/M01-auth-commands.e2e-spec.ts
@@ -1,0 +1,235 @@
+/**
+ * Matrix M01 — Auth commands (`auth login/status/logout`).
+ *
+ * Standalone: one instance with `--auth`.
+ * Auth axis covered: AUTH-STORED (saved API key in OS keyring).
+ *
+ * Prep (per suite):
+ *  1. Spawn @revisium/standalone with `--auth` and `ADMIN_PASSWORD=test-admin`.
+ *  2. Login via REST as admin to obtain a JWT.
+ *  3. Mint two API keys via `POST /api/organizations/admin/api-keys`:
+ *       - "default" (long-lived, the implicit credential name)
+ *       - "automation" (short-lived, named credential)
+ *  4. Allocate a per-suite credential-store service name so saved keys do not
+ *     collide with the developer's real OS keyring.
+ *
+ * Each test runs in a fresh workspace tempdir (`createWorkspace()`) and
+ * writes its own `revisium-cli.config.json` when needed.
+ */
+
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  uniqueCredentialStoreService,
+  writeWorkspaceConfig,
+} from '../utils/matrix-workspace';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M01 — auth commands', () => {
+  let standalone: StandaloneInstance;
+  let defaultApiKey: string;
+  let automationApiKey: string;
+  let credentialStoreService: string;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    defaultApiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'default' })
+    ).apiKey;
+    automationApiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'automation' })
+    ).apiKey;
+    credentialStoreService = uniqueCredentialStoreService();
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function newWorkspace(): string {
+    const ws = createWorkspace('revisium-cli-matrix-auth-');
+    workspaces.push(ws);
+    return ws;
+  }
+
+  function envWithStore(
+    extra: Record<string, string> = {},
+  ): Record<string, string> {
+    return {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_CREDENTIAL_STORE_SERVICE: credentialStoreService,
+      ...extra,
+    };
+  }
+
+  it('saves an API key for an --instance and surfaces it in auth status', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      instances: {
+        local: { baseUrl: standalone.baseUrl, authMode: 'stored' },
+      },
+    });
+    const env = envWithStore();
+
+    const login = await runCli(
+      ['auth', 'login', '--instance', 'local', '--api-key-stdin'],
+      { cwd: workspace, env, stdin: defaultApiKey + '\n' },
+    );
+    expect(login.exitCode).toBe(0);
+
+    const status = await runCli(['auth', 'status', '--instance', 'local'], {
+      cwd: workspace,
+      env,
+    });
+    expect(status.exitCode).toBe(0);
+    expect(status.stdout).toContain('Saved credential found');
+    expect(status.stdout).toContain('Auth mode: stored');
+  });
+
+  it('saves a named credential under --credential <name>', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      instances: {
+        local: { baseUrl: standalone.baseUrl, authMode: 'stored' },
+      },
+    });
+    const env = envWithStore();
+
+    const login = await runCli(
+      [
+        'auth',
+        'login',
+        '--instance',
+        'local',
+        '--credential',
+        'automation',
+        '--api-key-stdin',
+      ],
+      { cwd: workspace, env, stdin: automationApiKey + '\n' },
+    );
+    expect(login.exitCode).toBe(0);
+
+    const automationStatus = await runCli(
+      ['auth', 'status', '--instance', 'local', '--credential', 'automation'],
+      { cwd: workspace, env },
+    );
+    expect(automationStatus.stdout).toContain('Saved credential found');
+
+    const defaultStatus = await runCli(
+      ['auth', 'status', '--instance', 'local'],
+      { cwd: workspace, env },
+    );
+    expect(defaultStatus.stdout).toContain('No saved credential found');
+  });
+
+  it('refuses to login on an authMode "none" instance without --force', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      instances: {
+        sandbox: { baseUrl: standalone.baseUrl, authMode: 'none' },
+      },
+    });
+    const env = envWithStore();
+
+    const login = await runCli(
+      ['auth', 'login', '--instance', 'sandbox', '--api-key-stdin'],
+      { cwd: workspace, env, stdin: defaultApiKey + '\n' },
+    );
+    expect(login.exitCode).not.toBe(0);
+    expect(login.stderr.toLowerCase()).toContain('authmode');
+
+    const forced = await runCli(
+      ['auth', 'login', '--instance', 'sandbox', '--api-key-stdin', '--force'],
+      { cwd: workspace, env, stdin: defaultApiKey + '\n' },
+    );
+    expect(forced.exitCode).toBe(0);
+  });
+
+  it('reports "bypassed" status for authMode "none" instances', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      instances: {
+        sandbox: { baseUrl: standalone.baseUrl, authMode: 'none' },
+      },
+    });
+    const env = envWithStore();
+
+    const status = await runCli(['auth', 'status', '--instance', 'sandbox'], {
+      cwd: workspace,
+      env,
+    });
+    expect(status.exitCode).toBe(0);
+    expect(status.stdout).toContain(
+      'Saved credentials are bypassed for authMode "none"',
+    );
+  });
+
+  it('removes a stored credential via auth logout --instance', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      instances: {
+        local: { baseUrl: standalone.baseUrl, authMode: 'stored' },
+      },
+    });
+    const env = envWithStore();
+
+    await runCli(['auth', 'login', '--instance', 'local', '--api-key-stdin'], {
+      cwd: workspace,
+      env,
+      stdin: defaultApiKey + '\n',
+    });
+
+    const logout = await runCli(['auth', 'logout', '--instance', 'local'], {
+      cwd: workspace,
+      env,
+    });
+    expect(logout.exitCode).toBe(0);
+
+    const status = await runCli(['auth', 'status', '--instance', 'local'], {
+      cwd: workspace,
+      env,
+    });
+    expect(status.stdout).toContain('No saved credential found');
+  });
+
+  it('login --url derives the instance for first-time setup', async () => {
+    const workspace = newWorkspace();
+    const env = envWithStore();
+
+    const login = await runCli(
+      ['auth', 'login', '--url', standalone.url(), '--api-key-stdin'],
+      { cwd: workspace, env, stdin: defaultApiKey + '\n' },
+    );
+    expect(login.exitCode).toBe(0);
+
+    const status = await runCli(['auth', 'status', '--url', standalone.url()], {
+      cwd: workspace,
+      env,
+    });
+    expect(status.stdout).toContain('Saved credential found');
+  });
+
+  it('emits a copy-pasteable login hint when no saved credential is present', async () => {
+    const workspace = newWorkspace();
+    const env = envWithStore();
+
+    const status = await runCli(['auth', 'status', '--url', standalone.url()], {
+      cwd: workspace,
+      env,
+    });
+    expect(status.exitCode).toBe(0);
+    expect(status.stdout).toMatch(/auth login.*--api-key/);
+  });
+});

--- a/e2e/matrix/M02-instance-commands.e2e-spec.ts
+++ b/e2e/matrix/M02-instance-commands.e2e-spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Matrix M02 — Instance commands (`instance add/list/show/remove`).
+ *
+ * Standalone: one instance with `--auth` (commands operate on the workspace
+ * config only, but a real baseUrl is needed for URL normalization).
+ *
+ * Prep:
+ *  1. Spawn standalone with `--auth` and `ADMIN_PASSWORD=test-admin`.
+ *  2. Login as admin (so the test can mint an API key for the
+ *     `--with-credentials` removal case).
+ *  3. Per-test: empty workspace tempdir; no pre-seeded config.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  uniqueCredentialStoreService,
+} from '../utils/matrix-workspace';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M02 — instance commands', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const credentialStoreService = uniqueCredentialStoreService();
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'matrix-instance' })
+    ).apiKey;
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function newWorkspace(): string {
+    const ws = createWorkspace('revisium-cli-matrix-instance-');
+    workspaces.push(ws);
+    return ws;
+  }
+
+  function readWorkspaceConfig(workspace: string): unknown {
+    const filePath = path.join(
+      workspace,
+      '.revisium',
+      'revisium-cli.config.json',
+    );
+    if (!fs.existsSync(filePath)) return undefined;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  }
+
+  function env(): Record<string, string> {
+    return {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_CREDENTIAL_STORE_SERVICE: credentialStoreService,
+    };
+  }
+
+  it('instance add writes a non-secret entry into the workspace config', async () => {
+    const workspace = newWorkspace();
+    const result = await runCli(
+      ['instance', 'add', 'local', '--url', standalone.url(), '--auth', 'none'],
+      { cwd: workspace, env: env() },
+    );
+    expect(result.exitCode).toBe(0);
+
+    const config = readWorkspaceConfig(workspace) as {
+      instances: Record<string, { baseUrl: string; authMode?: string }>;
+    };
+    expect(config.instances.local.authMode).toBe('none');
+    expect(config.instances.local.baseUrl).toContain(
+      `localhost:${standalone.port}`,
+    );
+  });
+
+  it('instance add accepts a full revisium URL but stores only the host', async () => {
+    const workspace = newWorkspace();
+    const result = await runCli(
+      [
+        'instance',
+        'add',
+        'cloud',
+        '--url',
+        standalone.url({ project: 'whatever' }),
+      ],
+      { cwd: workspace, env: env() },
+    );
+    expect(result.exitCode).toBe(0);
+
+    const config = readWorkspaceConfig(workspace) as {
+      instances: Record<string, { baseUrl: string }>;
+    };
+    expect(config.instances.cloud.baseUrl).not.toContain('whatever');
+  });
+
+  it('instance list returns all configured instances sorted by name', async () => {
+    const workspace = newWorkspace();
+    await runCli(['instance', 'add', 'beta', '--url', standalone.url()], {
+      cwd: workspace,
+      env: env(),
+    });
+    await runCli(['instance', 'add', 'alpha', '--url', standalone.url()], {
+      cwd: workspace,
+      env: env(),
+    });
+
+    const list = await runCli(['instance', 'list', '--json'], {
+      cwd: workspace,
+      env: env(),
+    });
+    expect(list.exitCode).toBe(0);
+    const payload = JSON.parse(list.stdout) as {
+      instances: Array<{ name: string }>;
+    };
+    expect(payload.instances.map((entry) => entry.name)).toEqual([
+      'alpha',
+      'beta',
+    ]);
+  });
+
+  it('instance show prints baseUrl and authMode for the named instance', async () => {
+    const workspace = newWorkspace();
+    await runCli(
+      [
+        'instance',
+        'add',
+        'local',
+        '--url',
+        standalone.url(),
+        '--auth',
+        'stored',
+      ],
+      { cwd: workspace, env: env() },
+    );
+
+    const show = await runCli(['instance', 'show', 'local'], {
+      cwd: workspace,
+      env: env(),
+    });
+    expect(show.exitCode).toBe(0);
+    expect(show.stdout).toContain('Auth mode: stored');
+    expect(show.stdout).toMatch(/localhost:\d+/);
+  });
+
+  it('instance remove drops the entry; --with-credentials clears the OS keyring entry', async () => {
+    const workspace = newWorkspace();
+    await runCli(
+      [
+        'instance',
+        'add',
+        'local',
+        '--url',
+        standalone.url(),
+        '--auth',
+        'stored',
+      ],
+      { cwd: workspace, env: env() },
+    );
+    await runCli(['auth', 'login', '--instance', 'local', '--api-key-stdin'], {
+      cwd: workspace,
+      env: env(),
+      stdin: apiKey + '\n',
+    });
+
+    const remove = await runCli(
+      ['instance', 'remove', 'local', '--with-credentials'],
+      { cwd: workspace, env: env() },
+    );
+    expect(remove.exitCode).toBe(0);
+
+    const status = await runCli(['auth', 'status', '--url', standalone.url()], {
+      cwd: workspace,
+      env: env(),
+    });
+    expect(status.stdout).toContain('No saved credential found');
+  });
+
+  it('rejects re-adding an existing instance unless --force', async () => {
+    const workspace = newWorkspace();
+    await runCli(['instance', 'add', 'local', '--url', standalone.url()], {
+      cwd: workspace,
+      env: env(),
+    });
+    const dup = await runCli(
+      ['instance', 'add', 'local', '--url', standalone.url()],
+      { cwd: workspace, env: env() },
+    );
+    expect(dup.exitCode).not.toBe(0);
+
+    const forced = await runCli(
+      ['instance', 'add', 'local', '--url', standalone.url(), '--force'],
+      { cwd: workspace, env: env() },
+    );
+    expect(forced.exitCode).toBe(0);
+  });
+});

--- a/e2e/matrix/M02-instance-commands.e2e-spec.ts
+++ b/e2e/matrix/M02-instance-commands.e2e-spec.ts
@@ -45,7 +45,9 @@ describe('M02 — instance commands', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function newWorkspace(): string {

--- a/e2e/matrix/M03-context-commands.e2e-spec.ts
+++ b/e2e/matrix/M03-context-commands.e2e-spec.ts
@@ -63,7 +63,7 @@ describe('M03 — context commands', () => {
       REVISIUM_API_KEY: apiKey,
       REVISIUM_CREDENTIAL_STORE_SERVICE: credentialStoreService,
     };
-    await runCli(
+    const addInstance = await runCli(
       [
         'instance',
         'add',
@@ -75,7 +75,16 @@ describe('M03 — context commands', () => {
       ],
       { cwd: workspace, env },
     );
+    expect(addInstance.exitCode).toBe(0);
     return { workspace, env };
+  }
+
+  async function runCliExpectOk(
+    args: string[],
+    options: Parameters<typeof runCli>[1],
+  ): Promise<void> {
+    const result = await runCli(args, options);
+    expect(result.exitCode).toBe(0);
   }
 
   function readConfig(workspace: string): {
@@ -154,7 +163,7 @@ describe('M03 — context commands', () => {
 
   it('context list / show / use round-trip', async () => {
     const { workspace, env } = await setupWorkspace();
-    await runCli(
+    await runCliExpectOk(
       [
         'context',
         'create',
@@ -168,7 +177,7 @@ describe('M03 — context commands', () => {
       ],
       { cwd: workspace, env },
     );
-    await runCli(
+    await runCliExpectOk(
       [
         'context',
         'create',
@@ -204,12 +213,13 @@ describe('M03 — context commands', () => {
     expect(readConfig(workspace).currentContext).toBe('taxonomy-local');
 
     const show = await runCli(['context', 'show'], { cwd: workspace, env });
+    expect(show.exitCode).toBe(0);
     expect(show.stdout).toContain('taxonomy-local');
   });
 
   it('context remove drops the entry and clears currentContext when active', async () => {
     const { workspace, env } = await setupWorkspace();
-    await runCli(
+    await runCliExpectOk(
       [
         'context',
         'create',
@@ -223,7 +233,7 @@ describe('M03 — context commands', () => {
       ],
       { cwd: workspace, env },
     );
-    await runCli(['context', 'use', 'dictionary-local'], {
+    await runCliExpectOk(['context', 'use', 'dictionary-local'], {
       cwd: workspace,
       env,
     });
@@ -240,7 +250,7 @@ describe('M03 — context commands', () => {
 
   it('rejects head/non-draft contexts when used by mutating commands', async () => {
     const { workspace, env } = await setupWorkspace();
-    await runCli(
+    await runCliExpectOk(
       [
         'context',
         'create',

--- a/e2e/matrix/M03-context-commands.e2e-spec.ts
+++ b/e2e/matrix/M03-context-commands.e2e-spec.ts
@@ -1,0 +1,258 @@
+/**
+ * Matrix M03 — Context commands (`context create/list/show/use/remove`).
+ *
+ * Standalone: one `--auth` instance with two pre-seeded projects so context
+ * targets resolve to real revisions.
+ *
+ * Prep:
+ *  1. Spawn standalone with `--auth`, login, mint API key.
+ *  2. Seed projects `dictionary` and `taxonomy` with default `master` branch.
+ *  3. Per-test: empty workspace tempdir; `instance add local` so contexts
+ *     can reference it.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  uniqueCredentialStoreService,
+} from '../utils/matrix-workspace';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M03 — context commands', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const credentialStoreService = uniqueCredentialStoreService();
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'matrix-context' })
+    ).apiKey;
+    await standalone.api.createProject('admin', 'dictionary');
+    await standalone.api.createProject('admin', 'taxonomy');
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  async function setupWorkspace(): Promise<{
+    workspace: string;
+    env: Record<string, string>;
+  }> {
+    const workspace = createWorkspace('revisium-cli-matrix-context-');
+    workspaces.push(workspace);
+    const env: Record<string, string> = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_API_KEY: apiKey,
+      REVISIUM_CREDENTIAL_STORE_SERVICE: credentialStoreService,
+    };
+    await runCli(
+      [
+        'instance',
+        'add',
+        'local',
+        '--url',
+        standalone.url(),
+        '--auth',
+        'stored',
+      ],
+      { cwd: workspace, env },
+    );
+    return { workspace, env };
+  }
+
+  function readConfig(workspace: string): {
+    currentContext?: string;
+    contexts?: Record<string, unknown>;
+  } {
+    const file = path.join(workspace, '.revisium', 'revisium-cli.config.json');
+    return JSON.parse(fs.readFileSync(file, 'utf-8')) as {
+      currentContext?: string;
+      contexts?: Record<string, unknown>;
+    };
+  }
+
+  it('context create --instance writes all parts to the workspace config', async () => {
+    const { workspace, env } = await setupWorkspace();
+    const result = await runCli(
+      [
+        'context',
+        'create',
+        'dictionary-local',
+        '--instance',
+        'local',
+        '--org',
+        'admin',
+        '--project',
+        'dictionary',
+        '--branch',
+        'master',
+        '--revision',
+        'draft',
+      ],
+      { cwd: workspace, env },
+    );
+    expect(result.exitCode).toBe(0);
+
+    const config = readConfig(workspace);
+    expect(config.contexts).toMatchObject({
+      'dictionary-local': {
+        instance: 'local',
+        organization: 'admin',
+        project: 'dictionary',
+        branch: 'master',
+        revision: 'draft',
+      },
+    });
+  });
+
+  it('context create --url parses host/org/project/branch[:rev]', async () => {
+    const { workspace, env } = await setupWorkspace();
+    const result = await runCli(
+      [
+        'context',
+        'create',
+        'dictionary-from-url',
+        '--url',
+        standalone.url({
+          project: 'dictionary',
+          branch: 'master',
+          revision: 'draft',
+        }),
+      ],
+      { cwd: workspace, env },
+    );
+    expect(result.exitCode).toBe(0);
+
+    const config = readConfig(workspace);
+    expect(config.contexts).toHaveProperty('dictionary-from-url');
+  });
+
+  it('context list / show / use round-trip', async () => {
+    const { workspace, env } = await setupWorkspace();
+    await runCli(
+      [
+        'context',
+        'create',
+        'dictionary-local',
+        '--instance',
+        'local',
+        '--org',
+        'admin',
+        '--project',
+        'dictionary',
+      ],
+      { cwd: workspace, env },
+    );
+    await runCli(
+      [
+        'context',
+        'create',
+        'taxonomy-local',
+        '--instance',
+        'local',
+        '--org',
+        'admin',
+        '--project',
+        'taxonomy',
+      ],
+      { cwd: workspace, env },
+    );
+
+    const list = await runCli(['context', 'list', '--json'], {
+      cwd: workspace,
+      env,
+    });
+    expect(list.exitCode).toBe(0);
+    const listed = JSON.parse(list.stdout) as {
+      contexts: Array<{ name: string }>;
+    };
+    expect(listed.contexts.map((c) => c.name).sort()).toEqual([
+      'dictionary-local',
+      'taxonomy-local',
+    ]);
+
+    const use = await runCli(['context', 'use', 'taxonomy-local'], {
+      cwd: workspace,
+      env,
+    });
+    expect(use.exitCode).toBe(0);
+    expect(readConfig(workspace).currentContext).toBe('taxonomy-local');
+
+    const show = await runCli(['context', 'show'], { cwd: workspace, env });
+    expect(show.stdout).toContain('taxonomy-local');
+  });
+
+  it('context remove drops the entry and clears currentContext when active', async () => {
+    const { workspace, env } = await setupWorkspace();
+    await runCli(
+      [
+        'context',
+        'create',
+        'dictionary-local',
+        '--instance',
+        'local',
+        '--org',
+        'admin',
+        '--project',
+        'dictionary',
+      ],
+      { cwd: workspace, env },
+    );
+    await runCli(['context', 'use', 'dictionary-local'], {
+      cwd: workspace,
+      env,
+    });
+
+    const remove = await runCli(['context', 'remove', 'dictionary-local'], {
+      cwd: workspace,
+      env,
+    });
+    expect(remove.exitCode).toBe(0);
+    expect(readConfig(workspace).currentContext).toBeUndefined();
+  });
+
+  it('rejects head/non-draft contexts when used by mutating commands', async () => {
+    const { workspace, env } = await setupWorkspace();
+    await runCli(
+      [
+        'context',
+        'create',
+        'dictionary-head',
+        '--instance',
+        'local',
+        '--org',
+        'admin',
+        '--project',
+        'dictionary',
+        '--branch',
+        'master',
+        '--revision',
+        'head',
+      ],
+      { cwd: workspace, env },
+    );
+
+    const ensure = await runCli(
+      ['project', 'ensure', '--context', 'dictionary-head'],
+      { cwd: workspace, env },
+    );
+    expect(ensure.exitCode).not.toBe(0);
+    expect(ensure.stderr.toLowerCase()).toContain('draft');
+  });
+});

--- a/e2e/matrix/M03-context-commands.e2e-spec.ts
+++ b/e2e/matrix/M03-context-commands.e2e-spec.ts
@@ -47,7 +47,9 @@ describe('M03 — context commands', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   async function setupWorkspace(): Promise<{
@@ -140,7 +142,14 @@ describe('M03 — context commands', () => {
     expect(result.exitCode).toBe(0);
 
     const config = readConfig(workspace);
-    expect(config.contexts).toHaveProperty('dictionary-from-url');
+    expect(config.contexts).toMatchObject({
+      'dictionary-from-url': {
+        organization: 'admin',
+        project: 'dictionary',
+        branch: 'master',
+        revision: 'draft',
+      },
+    });
   });
 
   it('context list / show / use round-trip', async () => {
@@ -224,7 +233,9 @@ describe('M03 — context commands', () => {
       env,
     });
     expect(remove.exitCode).toBe(0);
-    expect(readConfig(workspace).currentContext).toBeUndefined();
+    const config = readConfig(workspace);
+    expect(config.currentContext).toBeUndefined();
+    expect(config.contexts ?? {}).not.toHaveProperty('dictionary-local');
   });
 
   it('rejects head/non-draft contexts when used by mutating commands', async () => {

--- a/e2e/matrix/M04-project-ensure.e2e-spec.ts
+++ b/e2e/matrix/M04-project-ensure.e2e-spec.ts
@@ -16,6 +16,7 @@ import {
   CLEAR_REVISIUM_ENV,
   createWorkspace,
   removeWorkspace,
+  uniqueCredentialStoreService,
   writeWorkspaceConfig,
 } from '../utils/matrix-workspace';
 import {
@@ -44,7 +45,9 @@ describe('M04 — project ensure', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function freshProjectName(prefix: string = 'm04'): string {
@@ -179,26 +182,37 @@ describe('M04 — project ensure', () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it('resolves saved credential via --instance / --context', async () => {
+  it('resolves saved credential via --context (no --token / REVISIUM_API_KEY)', async () => {
+    const project = freshProjectName();
     const workspace = newWorkspace();
     writeWorkspaceConfig(workspace, {
       instances: { local: { baseUrl: standalone.baseUrl, authMode: 'stored' } },
+      contexts: {
+        'local-default': {
+          instance: 'local',
+          organization: 'admin',
+          project,
+        },
+      },
     });
     const env: Record<string, string> = {
       ...CLEAR_REVISIUM_ENV,
-      REVISIUM_CREDENTIAL_STORE_SERVICE: 'revisium-cli-e2e-m04',
+      REVISIUM_CREDENTIAL_STORE_SERVICE: uniqueCredentialStoreService(),
     };
-    await runCli(['auth', 'login', '--instance', 'local', '--api-key-stdin'], {
-      cwd: workspace,
-      env,
-      stdin: apiKey + '\n',
-    });
+    const login = await runCli(
+      ['auth', 'login', '--instance', 'local', '--api-key-stdin'],
+      { cwd: workspace, env, stdin: apiKey + '\n' },
+    );
+    expect(login.exitCode).toBe(0);
 
-    const project = freshProjectName();
+    // No --url / --token / REVISIUM_API_KEY: target + credential resolve via
+    // the workspace --context entirely.
     const result = await runCli(
-      ['project', 'ensure', '--url', standalone.url({ project }), '--json'],
+      ['project', 'ensure', '--context', 'local-default', '--json'],
       { cwd: workspace, env },
     );
     expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as { project: string };
+    expect(summary.project).toBe(project);
   });
 });

--- a/e2e/matrix/M04-project-ensure.e2e-spec.ts
+++ b/e2e/matrix/M04-project-ensure.e2e-spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Matrix M04 — `project ensure` against a fresh standalone.
+ *
+ * Standalone: one `--auth` instance, no projects pre-seeded.
+ *
+ * Prep:
+ *  1. Spawn standalone with `--auth` and `ADMIN_PASSWORD=test-admin`.
+ *  2. Login as admin, mint API key (used as `REVISIUM_API_KEY`).
+ *  3. Per-test: a fresh workspace tempdir; the standalone may already have
+ *     leftover projects from previous tests (see project name randomization
+ *     in `freshProjectName`).
+ */
+
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  writeWorkspaceConfig,
+} from '../utils/matrix-workspace';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M04 — project ensure', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', {
+        name: 'matrix-project-ensure',
+      })
+    ).apiKey;
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function freshProjectName(prefix: string = 'm04'): string {
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function newWorkspace(): string {
+    const ws = createWorkspace('revisium-cli-matrix-project-ensure-');
+    workspaces.push(ws);
+    return ws;
+  }
+
+  function envWithApiKey(): Record<string, string> {
+    return { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey };
+  }
+
+  it('creates a brand-new project + master branch on first run', async () => {
+    const workspace = newWorkspace();
+    const project = freshProjectName();
+    const result = await runCli(
+      ['project', 'ensure', '--url', standalone.url({ project }), '--json'],
+      { cwd: workspace, env: envWithApiKey() },
+    );
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as {
+      projectStatus: string;
+      branchStatus: string;
+      organization: string;
+      project: string;
+      branch: string;
+    };
+    expect(summary).toMatchObject({
+      organization: 'admin',
+      project,
+      branch: 'master',
+      projectStatus: 'created',
+      branchStatus: 'created',
+    });
+    expect(await standalone.api.projectExists('admin', project)).toBe(true);
+  });
+
+  it('reports skipped on idempotent re-run', async () => {
+    const workspace = newWorkspace();
+    const project = freshProjectName();
+    await runCli(['project', 'ensure', '--url', standalone.url({ project })], {
+      cwd: workspace,
+      env: envWithApiKey(),
+    });
+    const second = await runCli(
+      ['project', 'ensure', '--url', standalone.url({ project }), '--json'],
+      { cwd: workspace, env: envWithApiKey() },
+    );
+    expect(second.exitCode).toBe(0);
+    const summary = JSON.parse(second.stdout) as {
+      projectStatus: string;
+      branchStatus: string;
+    };
+    expect(summary.projectStatus).toBe('skipped');
+    expect(summary.branchStatus).toBe('skipped');
+  });
+
+  it('--dry-run reports created without writing', async () => {
+    const workspace = newWorkspace();
+    const project = freshProjectName();
+    const dry = await runCli(
+      [
+        'project',
+        'ensure',
+        '--url',
+        standalone.url({ project }),
+        '--dry-run',
+        '--json',
+      ],
+      { cwd: workspace, env: envWithApiKey() },
+    );
+    expect(dry.exitCode).toBe(0);
+    const summary = JSON.parse(dry.stdout) as {
+      dryRun: boolean;
+      projectStatus: string;
+    };
+    expect(summary.dryRun).toBe(true);
+    expect(summary.projectStatus).toBe('created');
+    expect(await standalone.api.projectExists('admin', project)).toBe(false);
+  });
+
+  it('non-default branch creates a branch from rootBranch head', async () => {
+    const workspace = newWorkspace();
+    const project = freshProjectName();
+    await runCli(['project', 'ensure', '--url', standalone.url({ project })], {
+      cwd: workspace,
+      env: envWithApiKey(),
+    });
+
+    const result = await runCli(
+      [
+        'project',
+        'ensure',
+        '--url',
+        standalone.url({ project, branch: 'feature' }),
+        '--json',
+      ],
+      { cwd: workspace, env: envWithApiKey() },
+    );
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as {
+      projectStatus: string;
+      branchStatus: string;
+    };
+    expect(summary.projectStatus).toBe('skipped');
+    expect(summary.branchStatus).toBe('created');
+  });
+
+  it('explicit --token overrides REVISIUM_API_KEY', async () => {
+    const workspace = newWorkspace();
+    const project = freshProjectName();
+    const adminToken = await standalone.api.login('admin', 'test-admin');
+    const result = await runCli(
+      [
+        'project',
+        'ensure',
+        '--url',
+        standalone.url({ project }),
+        '--token',
+        adminToken,
+        '--json',
+      ],
+      {
+        cwd: workspace,
+        env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: 'wrong-key' },
+      },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('resolves saved credential via --instance / --context', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      instances: { local: { baseUrl: standalone.baseUrl, authMode: 'stored' } },
+    });
+    const env: Record<string, string> = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_CREDENTIAL_STORE_SERVICE: 'revisium-cli-e2e-m04',
+    };
+    await runCli(['auth', 'login', '--instance', 'local', '--api-key-stdin'], {
+      cwd: workspace,
+      env,
+      stdin: apiKey + '\n',
+    });
+
+    const project = freshProjectName();
+    const result = await runCli(
+      ['project', 'ensure', '--url', standalone.url({ project }), '--json'],
+      { cwd: workspace, env },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/e2e/matrix/M05-endpoint-commands.e2e-spec.ts
+++ b/e2e/matrix/M05-endpoint-commands.e2e-spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Matrix M05 — `endpoint ensure` and `endpoint list`.
+ *
+ * Standalone: one `--auth` instance.
+ *
+ * Prep:
+ *  1. Spawn standalone, login, mint API key.
+ *  2. Create project `dictionary` and seed table `Tag` so the draft revision
+ *     is non-empty (endpoints are created on a revision, not the project).
+ *  3. Per-test workspace tempdir.
+ */
+
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+} from '../utils/matrix-workspace';
+import { tagSchema } from '../utils/matrix-fixtures';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M05 — endpoint commands', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const projectName = `m05-${Date.now()}`;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'matrix-endpoint' })
+    ).apiKey;
+    await standalone.api.createProject('admin', projectName);
+    await standalone.api.seedTable({
+      organization: 'admin',
+      project: projectName,
+      tableId: 'Tag',
+      schema: tagSchema(),
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function newWorkspace(): string {
+    const ws = createWorkspace('revisium-cli-matrix-endpoint-');
+    workspaces.push(ws);
+    return ws;
+  }
+
+  function env(): Record<string, string> {
+    return { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey };
+  }
+
+  it('endpoint ensure creates REST_API once and is idempotent', async () => {
+    const workspace = newWorkspace();
+    const url = standalone.url({ project: projectName });
+
+    const first = await runCli(
+      ['endpoint', 'ensure', '--url', url, '--type', 'REST_API', '--json'],
+      { cwd: workspace, env: env() },
+    );
+    expect(first.exitCode).toBe(0);
+    expect(JSON.parse(first.stdout)).toMatchObject({ status: 'created' });
+
+    const second = await runCli(
+      ['endpoint', 'ensure', '--url', url, '--type', 'REST_API', '--json'],
+      { cwd: workspace, env: env() },
+    );
+    expect(second.exitCode).toBe(0);
+    expect(JSON.parse(second.stdout)).toMatchObject({ status: 'skipped' });
+  });
+
+  it('--dry-run does not create the endpoint', async () => {
+    const workspace = newWorkspace();
+    const ephemeralProject = `m05-dry-${Date.now()}`;
+    await standalone.api.createProject('admin', ephemeralProject);
+    const url = standalone.url({ project: ephemeralProject });
+
+    const result = await runCli(
+      [
+        'endpoint',
+        'ensure',
+        '--url',
+        url,
+        '--type',
+        'GRAPHQL',
+        '--dry-run',
+        '--json',
+      ],
+      { cwd: workspace, env: env() },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      status: 'created',
+      dryRun: true,
+    });
+    const list = await standalone.api.listEndpoints('admin', ephemeralProject);
+    expect(list).toHaveLength(0);
+  });
+
+  it('rejects invalid --type values via parseEndpointType', async () => {
+    const workspace = newWorkspace();
+    const result = await runCli(
+      [
+        'endpoint',
+        'ensure',
+        '--url',
+        standalone.url({ project: projectName }),
+        '--type',
+        'NOPE',
+      ],
+      { cwd: workspace, env: env() },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('REST_API');
+  });
+
+  it('endpoint list returns both endpoint types in JSON form', async () => {
+    const workspace = newWorkspace();
+    const url = standalone.url({ project: projectName });
+    await runCli(['endpoint', 'ensure', '--url', url, '--type', 'REST_API'], {
+      cwd: workspace,
+      env: env(),
+    });
+    await runCli(['endpoint', 'ensure', '--url', url, '--type', 'GRAPHQL'], {
+      cwd: workspace,
+      env: env(),
+    });
+
+    const list = await runCli(['endpoint', 'list', '--url', url, '--json'], {
+      cwd: workspace,
+      env: env(),
+    });
+    expect(list.exitCode).toBe(0);
+    const payload = JSON.parse(list.stdout) as {
+      endpoints: Array<{ type: string }>;
+    };
+    expect(payload.endpoints.map((e) => e.type).sort()).toEqual([
+      'GRAPHQL',
+      'REST_API',
+    ]);
+  });
+
+  it('endpoint list reports "No generated endpoints found" when empty', async () => {
+    const workspace = newWorkspace();
+    const ephemeralProject = `m05-empty-${Date.now()}`;
+    await standalone.api.createProject('admin', ephemeralProject);
+    const url = standalone.url({ project: ephemeralProject });
+
+    const list = await runCli(['endpoint', 'list', '--url', url], {
+      cwd: workspace,
+      env: env(),
+    });
+    expect(list.exitCode).toBe(0);
+    expect(list.stdout).toContain('No generated endpoints found');
+  });
+});

--- a/e2e/matrix/M05-endpoint-commands.e2e-spec.ts
+++ b/e2e/matrix/M05-endpoint-commands.e2e-spec.ts
@@ -49,7 +49,9 @@ describe('M05 — endpoint commands', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function newWorkspace(): string {

--- a/e2e/matrix/M05-endpoint-commands.e2e-spec.ts
+++ b/e2e/matrix/M05-endpoint-commands.e2e-spec.ts
@@ -131,14 +131,16 @@ describe('M05 — endpoint commands', () => {
   it('endpoint list returns both endpoint types in JSON form', async () => {
     const workspace = newWorkspace();
     const url = standalone.url({ project: projectName });
-    await runCli(['endpoint', 'ensure', '--url', url, '--type', 'REST_API'], {
-      cwd: workspace,
-      env: env(),
-    });
-    await runCli(['endpoint', 'ensure', '--url', url, '--type', 'GRAPHQL'], {
-      cwd: workspace,
-      env: env(),
-    });
+    const ensureRest = await runCli(
+      ['endpoint', 'ensure', '--url', url, '--type', 'REST_API'],
+      { cwd: workspace, env: env() },
+    );
+    expect(ensureRest.exitCode).toBe(0);
+    const ensureGraphql = await runCli(
+      ['endpoint', 'ensure', '--url', url, '--type', 'GRAPHQL'],
+      { cwd: workspace, env: env() },
+    );
+    expect(ensureGraphql.exitCode).toBe(0);
 
     const list = await runCli(['endpoint', 'list', '--url', url, '--json'], {
       cwd: workspace,

--- a/e2e/matrix/M06-example-bootstrap.e2e-spec.ts
+++ b/e2e/matrix/M06-example-bootstrap.e2e-spec.ts
@@ -50,7 +50,9 @@ describe('M06 — example bootstrap', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function freshProject(prefix: string): string {
@@ -108,6 +110,7 @@ describe('M06 — example bootstrap', () => {
       ],
       { cwd: workspace, env, timeout: 120_000 },
     );
+    expect(second.exitCode).toBe(0);
     const secondSummary = JSON.parse(second.stdout) as {
       tables: { created: string[]; skipped: string[] };
       rows: { skipped: string[] };

--- a/e2e/matrix/M06-example-bootstrap.e2e-spec.ts
+++ b/e2e/matrix/M06-example-bootstrap.e2e-spec.ts
@@ -1,0 +1,434 @@
+/**
+ * Matrix M06 — `example bootstrap` end-to-end.
+ *
+ * Standalone: one `--auth` instance.
+ *
+ * Prep:
+ *  1. Spawn standalone, login, mint API key.
+ *  2. Per-test workspace tempdir + a fresh project name (avoids cross-test
+ *     interference). Bootstrap config files are written via
+ *     `writeBootstrapConfigFile()` so each test owns its on-disk fixture.
+ *  3. Conflict cases pre-seed the target project via REST before invoking
+ *     the CLI so the conflict path is exercised, not the create path.
+ */
+
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  writeBootstrapConfigFile,
+} from '../utils/matrix-workspace';
+import {
+  faqRows,
+  faqSchema,
+  tagBootstrapConfig,
+  tagRows,
+  tagSchema,
+} from '../utils/matrix-fixtures';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M06 — example bootstrap', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'matrix-bootstrap' })
+    ).apiKey;
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function freshProject(prefix: string): string {
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  }
+
+  function setup(): { workspace: string; env: Record<string, string> } {
+    const workspace = createWorkspace('revisium-cli-matrix-bootstrap-');
+    workspaces.push(workspace);
+    return {
+      workspace,
+      env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey },
+    };
+  }
+
+  it('creates everything on first run, reports skipped on second run', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-idem');
+    const configPath = writeBootstrapConfigFile(
+      workspace,
+      tagBootstrapConfig(project),
+    );
+
+    const first = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    expect(first.exitCode).toBe(0);
+    const firstSummary = JSON.parse(first.stdout) as {
+      tables: { created: string[] };
+      rows: { created: string[] };
+      endpoints: { created: string[] };
+    };
+    expect(firstSummary.tables.created).toEqual(['Tag']);
+    expect(firstSummary.rows.created).toHaveLength(3);
+    expect(firstSummary.endpoints.created).toEqual(['REST_API']);
+
+    const second = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    const secondSummary = JSON.parse(second.stdout) as {
+      tables: { created: string[]; skipped: string[] };
+      rows: { skipped: string[] };
+      endpoints: { skipped: string[] };
+    };
+    expect(secondSummary.tables.created).toEqual([]);
+    expect(secondSummary.tables.skipped).toEqual(['Tag']);
+    expect(secondSummary.rows.skipped).toHaveLength(3);
+    expect(secondSummary.endpoints.skipped).toEqual(['REST_API']);
+  });
+
+  it('--commit creates a revision id', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-commit');
+    const configPath = writeBootstrapConfigFile(
+      workspace,
+      tagBootstrapConfig(project),
+    );
+
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+        '--commit',
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as {
+      commit: { status: string; revisionId?: string };
+    };
+    expect(summary.commit.status).toBe('created');
+    expect(summary.commit.revisionId).toBeTruthy();
+  });
+
+  it('--dry-run does not write to the standalone', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-dry');
+    const configPath = writeBootstrapConfigFile(
+      workspace,
+      tagBootstrapConfig(project),
+    );
+
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+        '--dry-run',
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(await standalone.api.projectExists('admin', project)).toBe(false);
+  });
+
+  it('--dry-run on an existing populated rootBranch reports skipped (regression)', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-dry-existing');
+    await standalone.api.createProject('admin', project);
+    await standalone.api.seedTable({
+      organization: 'admin',
+      project,
+      tableId: 'Tag',
+      schema: tagSchema(),
+    });
+    for (const row of tagRows(3)) {
+      await standalone.api.seedRow({
+        organization: 'admin',
+        project,
+        tableId: row.tableId,
+        rowId: row.rowId,
+        data: row.data,
+      });
+    }
+
+    const configPath = writeBootstrapConfigFile(
+      workspace,
+      tagBootstrapConfig(project),
+    );
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project, branch: 'feature' }),
+        '--dry-run',
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as {
+      tables: { skipped: string[]; created: string[] };
+      rows: { skipped: string[]; created: string[] };
+    };
+    expect(summary.tables.skipped).toEqual(['Tag']);
+    expect(summary.tables.created).toEqual([]);
+    expect(summary.rows.created).toEqual([]);
+  });
+
+  it('--endpoint overrides config endpoints', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-override');
+    const configPath = writeBootstrapConfigFile(workspace, {
+      ...tagBootstrapConfig(project),
+      endpoints: ['REST_API'],
+    });
+
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+        '--endpoint',
+        'GRAPHQL',
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as {
+      endpoints: { created: string[] };
+    };
+    expect(summary.endpoints.created).toEqual(['GRAPHQL']);
+  });
+
+  it('rejects schema conflicts without writing', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-conflict-table');
+    await standalone.api.createProject('admin', project);
+    await standalone.api.seedTable({
+      organization: 'admin',
+      project,
+      tableId: 'Tag',
+      schema: faqSchema(),
+    });
+
+    const configPath = writeBootstrapConfigFile(
+      workspace,
+      tagBootstrapConfig(project),
+    );
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/table conflict/i);
+  });
+
+  it('rejects row conflicts without writing', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-conflict-row');
+    await standalone.api.createProject('admin', project);
+    await standalone.api.seedTable({
+      organization: 'admin',
+      project,
+      tableId: 'Tag',
+      schema: tagSchema(),
+    });
+    await standalone.api.seedRow({
+      organization: 'admin',
+      project,
+      tableId: 'Tag',
+      rowId: 'tag-1',
+      data: { label: 'Different' },
+    });
+
+    const configPath = writeBootstrapConfigFile(
+      workspace,
+      tagBootstrapConfig(project),
+    );
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/row conflict/i);
+  });
+
+  it('rejects projectName mismatch', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-name-mismatch');
+    const configPath = writeBootstrapConfigFile(workspace, {
+      ...tagBootstrapConfig(project),
+      projectName: 'something-else',
+    });
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+      ],
+      { cwd: workspace, env },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('does not match target project');
+  });
+
+  it('rejects non-draft revision before any project is created (regression)', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-non-draft');
+    const configPath = writeBootstrapConfigFile(
+      workspace,
+      tagBootstrapConfig(project),
+    );
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project, revision: 'head' }),
+      ],
+      { cwd: workspace, env },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('requires a draft revision');
+    expect(await standalone.api.projectExists('admin', project)).toBe(false);
+  });
+
+  it.each([
+    ['empty file', () => ''],
+    ['array root', () => JSON.stringify([])],
+    ['endpoints not array', () => JSON.stringify({ endpoints: 'rest' })],
+    ['endpoint not string', () => JSON.stringify({ endpoints: [42] })],
+    [
+      'tables[0] missing schema',
+      () => JSON.stringify({ tables: [{ id: 'X' }] }),
+    ],
+    [
+      'tables[0].id empty',
+      () =>
+        JSON.stringify({ tables: [{ id: '', schema: { type: 'object' } }] }),
+    ],
+    [
+      'rows[0].rowId empty',
+      () =>
+        JSON.stringify({
+          rows: [{ tableId: 't', rowId: '', data: {} }],
+        }),
+    ],
+  ])('rejects invalid config: %s', async (_label, build) => {
+    const { workspace, env } = setup();
+    const configPath = writeBootstrapConfigFile(workspace, build());
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project: 'irrelevant' }),
+      ],
+      { cwd: workspace, env },
+    );
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('faq fixture round-trips cleanly', async () => {
+    const { workspace, env } = setup();
+    const project = freshProject('m06-faq');
+    const configPath = writeBootstrapConfigFile(workspace, {
+      projectName: project,
+      branchName: 'master',
+      endpoints: ['REST_API', 'GRAPHQL'],
+      tables: [{ id: 'FaqCategory', schema: faqSchema() }],
+      rows: faqRows(),
+      commitMessage: 'faq bootstrap',
+    });
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        standalone.url({ project }),
+        '--commit',
+        '--json',
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as {
+      tables: { created: string[] };
+      rows: { created: string[] };
+    };
+    expect(summary.tables.created).toEqual(['FaqCategory']);
+    expect(summary.rows.created).toHaveLength(2);
+  });
+});

--- a/e2e/matrix/M07-migrate.e2e-spec.ts
+++ b/e2e/matrix/M07-migrate.e2e-spec.ts
@@ -1,0 +1,227 @@
+/**
+ * Matrix M07 — `migrate save` and `migrate apply`.
+ *
+ * Standalone: one `--auth` instance.
+ *
+ * Prep:
+ *  1. Spawn standalone, login, mint API key.
+ *  2. Source project: create + seed table `Tag` + 3 rows.
+ *  3. Per-test workspace tempdir for the on-disk migration JSON.
+ */
+
+import * as fs from 'node:fs';
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  workspaceFile,
+} from '../utils/matrix-workspace';
+import { tagRows, tagSchema } from '../utils/matrix-fixtures';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M07 — migrate', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const sourceProject = `m07-source-${Date.now()}`;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'matrix-migrate' })
+    ).apiKey;
+    await standalone.api.createProject('admin', sourceProject);
+    await standalone.api.seedTable({
+      organization: 'admin',
+      project: sourceProject,
+      tableId: 'Tag',
+      schema: tagSchema(),
+    });
+    for (const row of tagRows(3)) {
+      await standalone.api.seedRow({
+        organization: 'admin',
+        project: sourceProject,
+        ...row,
+      });
+    }
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function setup(): { workspace: string; env: Record<string, string> } {
+    const workspace = createWorkspace('revisium-cli-matrix-migrate-');
+    workspaces.push(workspace);
+    return {
+      workspace,
+      env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey },
+    };
+  }
+
+  it('migrate save writes a non-empty migration JSON', async () => {
+    const { workspace, env } = setup();
+    const out = workspaceFile(workspace, 'migration.json');
+    const result = await runCli(
+      [
+        'migrate',
+        'save',
+        '--file',
+        out,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(fs.existsSync(out)).toBe(true);
+    const json = JSON.parse(fs.readFileSync(out, 'utf-8')) as unknown[];
+    expect(Array.isArray(json)).toBe(true);
+    expect(json.length).toBeGreaterThan(0);
+  });
+
+  it('migrate apply --commit creates the table on an empty target project', async () => {
+    const { workspace, env } = setup();
+    const targetProject = `m07-target-${Date.now()}`;
+    const migration = workspaceFile(workspace, 'migration.json');
+
+    await runCli(
+      [
+        'migrate',
+        'save',
+        '--file',
+        migration,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    await standalone.api.createProject('admin', targetProject);
+
+    const apply = await runCli(
+      [
+        'migrate',
+        'apply',
+        '--file',
+        migration,
+        '--commit',
+        '--url',
+        standalone.url({ project: targetProject }),
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    expect(apply.exitCode).toBe(0);
+
+    const tables = await standalone.api.listTables('admin', targetProject);
+    expect(tables.map((t) => t.id)).toContain('Tag');
+  });
+
+  it('migrate apply is idempotent on a re-run', async () => {
+    const { workspace, env } = setup();
+    const targetProject = `m07-idem-${Date.now()}`;
+    const migration = workspaceFile(workspace, 'migration.json');
+    await runCli(
+      [
+        'migrate',
+        'save',
+        '--file',
+        migration,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    await standalone.api.createProject('admin', targetProject);
+
+    const first = await runCli(
+      [
+        'migrate',
+        'apply',
+        '--file',
+        migration,
+        '--commit',
+        '--url',
+        standalone.url({ project: targetProject }),
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    expect(first.exitCode).toBe(0);
+
+    const second = await runCli(
+      [
+        'migrate',
+        'apply',
+        '--file',
+        migration,
+        '--commit',
+        '--url',
+        standalone.url({ project: targetProject }),
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    expect(second.exitCode).toBe(0);
+  });
+
+  it('migrate apply --create-project creates the project before applying', async () => {
+    const { workspace, env } = setup();
+    const targetProject = `m07-create-${Date.now()}`;
+    const migration = workspaceFile(workspace, 'migration.json');
+    await runCli(
+      [
+        'migrate',
+        'save',
+        '--file',
+        migration,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+
+    const apply = await runCli(
+      [
+        'migrate',
+        'apply',
+        '--file',
+        migration,
+        '--commit',
+        '--create-project',
+        '--url',
+        standalone.url({ project: targetProject }),
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    expect(apply.exitCode).toBe(0);
+    expect(await standalone.api.projectExists('admin', targetProject)).toBe(
+      true,
+    );
+  });
+
+  it('migrate apply against missing file fails fast', async () => {
+    const { workspace, env } = setup();
+    const result = await runCli(
+      [
+        'migrate',
+        'apply',
+        '--file',
+        workspaceFile(workspace, 'absent.json'),
+        '--commit',
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toLowerCase()).toMatch(/file|not found|enoent/);
+  });
+});

--- a/e2e/matrix/M07-migrate.e2e-spec.ts
+++ b/e2e/matrix/M07-migrate.e2e-spec.ts
@@ -57,7 +57,9 @@ describe('M07 — migrate', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function setup(): { workspace: string; env: Record<string, string> } {

--- a/e2e/matrix/M08-schema.e2e-spec.ts
+++ b/e2e/matrix/M08-schema.e2e-spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Matrix M08 — `schema save` and `schema create-migrations`.
+ *
+ * Standalone: one `--auth` instance.
+ *
+ * Prep:
+ *  1. Spawn standalone, login, mint API key.
+ *  2. Source project with three tables (`Tag`, `FaqCategory`, `Quest`).
+ *  3. Per-test workspace tempdir for the on-disk schema folder + migration.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  workspaceFile,
+} from '../utils/matrix-workspace';
+import { faqSchema, questSchema, tagSchema } from '../utils/matrix-fixtures';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M08 — schema', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const sourceProject = `m08-${Date.now()}`;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'matrix-schema' })
+    ).apiKey;
+    await standalone.api.createProject('admin', sourceProject);
+    for (const seed of [
+      { id: 'Tag', schema: tagSchema() },
+      { id: 'FaqCategory', schema: faqSchema() },
+      { id: 'Quest', schema: questSchema() },
+    ]) {
+      await standalone.api.seedTable({
+        organization: 'admin',
+        project: sourceProject,
+        tableId: seed.id,
+        schema: seed.schema,
+      });
+    }
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function setup(): { workspace: string; env: Record<string, string> } {
+    const workspace = createWorkspace('revisium-cli-matrix-schema-');
+    workspaces.push(workspace);
+    return {
+      workspace,
+      env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey },
+    };
+  }
+
+  it('schema save writes one JSON file per table', async () => {
+    const { workspace, env } = setup();
+    const folder = workspaceFile(workspace, 'schemas');
+    const result = await runCli(
+      [
+        'schema',
+        'save',
+        '--folder',
+        folder,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    const written = fs.readdirSync(folder).sort();
+    expect(written).toEqual(['FaqCategory.json', 'Quest.json', 'Tag.json']);
+  });
+
+  it('schema create-migrations is offline and produces a migration file', async () => {
+    const { workspace, env } = setup();
+    const folder = workspaceFile(workspace, 'schemas');
+    fs.mkdirSync(folder, { recursive: true });
+    fs.writeFileSync(
+      path.join(folder, 'Tag.json'),
+      JSON.stringify(tagSchema(), null, 2),
+    );
+    const out = workspaceFile(workspace, 'migration.json');
+    const result = await runCli(
+      ['schema', 'create-migrations', '--folder', folder, '--output', out],
+      { cwd: workspace, env, timeout: 60_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(fs.existsSync(out)).toBe(true);
+    const migration = JSON.parse(fs.readFileSync(out, 'utf-8')) as unknown[];
+    expect(Array.isArray(migration)).toBe(true);
+    expect(migration.length).toBeGreaterThan(0);
+  });
+
+  it('round-trip: schema save → create-migrations → migrate apply matches the source', async () => {
+    const { workspace, env } = setup();
+    const folder = workspaceFile(workspace, 'schemas');
+    const migration = workspaceFile(workspace, 'migration.json');
+    const targetProject = `m08-target-${Date.now()}`;
+
+    await runCli(
+      [
+        'schema',
+        'save',
+        '--folder',
+        folder,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 120_000 },
+    );
+    await runCli(
+      [
+        'schema',
+        'create-migrations',
+        '--folder',
+        folder,
+        '--output',
+        migration,
+      ],
+      { cwd: workspace, env, timeout: 60_000 },
+    );
+    await standalone.api.createProject('admin', targetProject);
+    const apply = await runCli(
+      [
+        'migrate',
+        'apply',
+        '--file',
+        migration,
+        '--commit',
+        '--url',
+        standalone.url({ project: targetProject }),
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    expect(apply.exitCode).toBe(0);
+
+    const tables = await standalone.api.listTables('admin', targetProject);
+    expect(tables.map((t) => t.id).sort()).toEqual([
+      'FaqCategory',
+      'Quest',
+      'Tag',
+    ]);
+  });
+});

--- a/e2e/matrix/M08-schema.e2e-spec.ts
+++ b/e2e/matrix/M08-schema.e2e-spec.ts
@@ -57,7 +57,9 @@ describe('M08 — schema', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function setup(): { workspace: string; env: Record<string, string> } {

--- a/e2e/matrix/M09-rows.e2e-spec.ts
+++ b/e2e/matrix/M09-rows.e2e-spec.ts
@@ -57,7 +57,9 @@ describe('M09 — rows save / upload', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function setup(): { workspace: string; env: Record<string, string> } {
@@ -101,7 +103,7 @@ describe('M09 — rows save / upload', () => {
       schema: questSchema(),
     });
 
-    await runCli(
+    const save = await runCli(
       [
         'rows',
         'save',
@@ -112,6 +114,7 @@ describe('M09 — rows save / upload', () => {
       ],
       { cwd: workspace, env, timeout: 180_000 },
     );
+    expect(save.exitCode).toBe(0);
     const upload = await runCli(
       [
         'rows',
@@ -138,7 +141,7 @@ describe('M09 — rows save / upload', () => {
       tableId: 'Quest',
       schema: questSchema(),
     });
-    await runCli(
+    const save = await runCli(
       [
         'rows',
         'save',
@@ -149,6 +152,7 @@ describe('M09 — rows save / upload', () => {
       ],
       { cwd: workspace, env, timeout: 180_000 },
     );
+    expect(save.exitCode).toBe(0);
 
     const upload = await runCli(
       [

--- a/e2e/matrix/M09-rows.e2e-spec.ts
+++ b/e2e/matrix/M09-rows.e2e-spec.ts
@@ -128,6 +128,12 @@ describe('M09 — rows save / upload', () => {
       { cwd: workspace, env, timeout: 240_000 },
     );
     expect(upload.exitCode).toBe(0);
+    const targetRows = await standalone.api.listRows(
+      'admin',
+      targetProject,
+      'Quest',
+    );
+    expect(targetRows).toHaveLength(50);
   });
 
   it('rows upload honours --batch <n>', async () => {
@@ -169,5 +175,11 @@ describe('M09 — rows save / upload', () => {
       { cwd: workspace, env, timeout: 240_000 },
     );
     expect(upload.exitCode).toBe(0);
+    const targetRows = await standalone.api.listRows(
+      'admin',
+      targetProject,
+      'Quest',
+    );
+    expect(targetRows).toHaveLength(50);
   });
 });

--- a/e2e/matrix/M09-rows.e2e-spec.ts
+++ b/e2e/matrix/M09-rows.e2e-spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Matrix M09 — `rows save` / `rows upload`.
+ *
+ * Standalone: one `--auth` instance.
+ *
+ * Prep:
+ *  1. Spawn standalone, login, mint API key.
+ *  2. Source project with table `Quest` + 50 rows.
+ *  3. Per-test workspace tempdir for the on-disk row data folder.
+ */
+
+import * as fs from 'node:fs';
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  workspaceFile,
+} from '../utils/matrix-workspace';
+import { questRows, questSchema } from '../utils/matrix-fixtures';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M09 — rows save / upload', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const sourceProject = `m09-${Date.now()}`;
+  const ROWS = questRows(50);
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (await standalone.api.mintApiKey('admin', { name: 'matrix-rows' }))
+      .apiKey;
+    await standalone.api.createProject('admin', sourceProject);
+    await standalone.api.seedTable({
+      organization: 'admin',
+      project: sourceProject,
+      tableId: 'Quest',
+      schema: questSchema(),
+    });
+    for (const row of ROWS) {
+      await standalone.api.seedRow({
+        organization: 'admin',
+        project: sourceProject,
+        ...row,
+      });
+    }
+  }, 240_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function setup(): { workspace: string; env: Record<string, string> } {
+    const workspace = createWorkspace('revisium-cli-matrix-rows-');
+    workspaces.push(workspace);
+    return {
+      workspace,
+      env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey },
+    };
+  }
+
+  it('rows save writes one folder per table with all rows', async () => {
+    const { workspace, env } = setup();
+    const folder = workspaceFile(workspace, 'data');
+    const result = await runCli(
+      [
+        'rows',
+        'save',
+        '--folder',
+        folder,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(fs.readdirSync(folder)).toContain('Quest');
+    const questDir = workspaceFile(workspace, 'data', 'Quest');
+    expect(fs.readdirSync(questDir).length).toBe(50);
+  });
+
+  it('rows upload --commit imports rows into an empty target', async () => {
+    const { workspace, env } = setup();
+    const folder = workspaceFile(workspace, 'data');
+    const targetProject = `m09-target-${Date.now()}`;
+    await standalone.api.createProject('admin', targetProject);
+    await standalone.api.seedTable({
+      organization: 'admin',
+      project: targetProject,
+      tableId: 'Quest',
+      schema: questSchema(),
+    });
+
+    await runCli(
+      [
+        'rows',
+        'save',
+        '--folder',
+        folder,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+    const upload = await runCli(
+      [
+        'rows',
+        'upload',
+        '--folder',
+        folder,
+        '--commit',
+        '--url',
+        standalone.url({ project: targetProject }),
+      ],
+      { cwd: workspace, env, timeout: 240_000 },
+    );
+    expect(upload.exitCode).toBe(0);
+  });
+
+  it('rows upload honours --batch <n>', async () => {
+    const { workspace, env } = setup();
+    const folder = workspaceFile(workspace, 'data');
+    const targetProject = `m09-batch-${Date.now()}`;
+    await standalone.api.createProject('admin', targetProject);
+    await standalone.api.seedTable({
+      organization: 'admin',
+      project: targetProject,
+      tableId: 'Quest',
+      schema: questSchema(),
+    });
+    await runCli(
+      [
+        'rows',
+        'save',
+        '--folder',
+        folder,
+        '--url',
+        standalone.url({ project: sourceProject }),
+      ],
+      { cwd: workspace, env, timeout: 180_000 },
+    );
+
+    const upload = await runCli(
+      [
+        'rows',
+        'upload',
+        '--folder',
+        folder,
+        '--batch',
+        '5',
+        '--commit',
+        '--url',
+        standalone.url({ project: targetProject }),
+      ],
+      { cwd: workspace, env, timeout: 240_000 },
+    );
+    expect(upload.exitCode).toBe(0);
+  });
+});

--- a/e2e/matrix/M10-sync.e2e-spec.ts
+++ b/e2e/matrix/M10-sync.e2e-spec.ts
@@ -1,0 +1,200 @@
+/**
+ * Matrix M10 — `sync schema/data/all` between two standalone instances.
+ *
+ * Standalone: TWO `--auth` instances on different ports.
+ *
+ * Prep:
+ *  1. Spawn `source` and `target` standalone instances.
+ *  2. Login as admin on each, mint API keys (`SOURCE_API_KEY` / `TARGET_API_KEY`).
+ *  3. Source: create project + seed tables + rows.
+ *  4. Target: create empty project (sync expects it to exist; for the
+ *     `sync all --create-project` matrix line, leave the target absent).
+ */
+
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+} from '../utils/matrix-workspace';
+import {
+  questRows,
+  questSchema,
+  tagRows,
+  tagSchema,
+} from '../utils/matrix-fixtures';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M10 — sync', () => {
+  let source: StandaloneInstance;
+  let target: StandaloneInstance;
+  let sourceApiKey: string;
+  let targetApiKey: string;
+  const sourceProject = `m10-source-${Date.now()}`;
+  const targetProject = `m10-target-${Date.now()}`;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    source = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    target = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+
+    await source.api.login('admin', 'test-admin');
+    await target.api.login('admin', 'test-admin');
+    sourceApiKey = (
+      await source.api.mintApiKey('admin', { name: 'matrix-sync-source' })
+    ).apiKey;
+    targetApiKey = (
+      await target.api.mintApiKey('admin', { name: 'matrix-sync-target' })
+    ).apiKey;
+
+    await source.api.createProject('admin', sourceProject);
+    await source.api.seedTable({
+      organization: 'admin',
+      project: sourceProject,
+      tableId: 'Tag',
+      schema: tagSchema(),
+    });
+    await source.api.seedTable({
+      organization: 'admin',
+      project: sourceProject,
+      tableId: 'Quest',
+      schema: questSchema(),
+    });
+    for (const row of [...tagRows(3), ...questRows(5)]) {
+      await source.api.seedRow({
+        organization: 'admin',
+        project: sourceProject,
+        ...row,
+      });
+    }
+
+    await target.api.createProject('admin', targetProject);
+  }, 360_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await Promise.all([source.stop(), target.stop()]);
+  });
+
+  function setup(): { workspace: string; env: Record<string, string> } {
+    const workspace = createWorkspace('revisium-cli-matrix-sync-');
+    workspaces.push(workspace);
+    return {
+      workspace,
+      env: {
+        ...CLEAR_REVISIUM_ENV,
+        REVISIUM_SOURCE_API_KEY: sourceApiKey,
+        REVISIUM_TARGET_API_KEY: targetApiKey,
+      },
+    };
+  }
+
+  function sourceUrl(): string {
+    return source.url({ project: sourceProject, revision: 'head' });
+  }
+
+  function targetUrl(): string {
+    return target.url({ project: targetProject });
+  }
+
+  it('sync schema copies tables from source to target', async () => {
+    const { workspace, env } = setup();
+    const result = await runCli(
+      [
+        'sync',
+        'schema',
+        '--source',
+        sourceUrl(),
+        '--target',
+        targetUrl(),
+        '--commit',
+      ],
+      { cwd: workspace, env, timeout: 240_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    const targetTables = await target.api.listTables('admin', targetProject);
+    expect(targetTables.map((t) => t.id).sort()).toEqual(['Quest', 'Tag']);
+  });
+
+  it('sync data copies rows once schemas match', async () => {
+    const { workspace, env } = setup();
+    await runCli(
+      [
+        'sync',
+        'schema',
+        '--source',
+        sourceUrl(),
+        '--target',
+        targetUrl(),
+        '--commit',
+      ],
+      { cwd: workspace, env, timeout: 240_000 },
+    );
+    const result = await runCli(
+      [
+        'sync',
+        'data',
+        '--source',
+        sourceUrl(),
+        '--target',
+        targetUrl(),
+        '--commit',
+      ],
+      { cwd: workspace, env, timeout: 240_000 },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('sync all --commit performs schema + data in one shot', async () => {
+    const fresh = `m10-all-${Date.now()}`;
+    await target.api.createProject('admin', fresh);
+
+    const { workspace, env } = setup();
+    const result = await runCli(
+      [
+        'sync',
+        'all',
+        '--source',
+        sourceUrl(),
+        '--target',
+        target.url({ project: fresh }),
+        '--commit',
+      ],
+      { cwd: workspace, env, timeout: 360_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    const targetTables = await target.api.listTables('admin', fresh);
+    expect(targetTables.map((t) => t.id).sort()).toEqual(['Quest', 'Tag']);
+  });
+
+  it('rejects mutually-exclusive auth: both ?token=... and REVISIUM_TARGET_TOKEN', async () => {
+    const { workspace } = setup();
+    const env: Record<string, string> = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_SOURCE_API_KEY: sourceApiKey,
+      REVISIUM_TARGET_TOKEN: 'env-token',
+    };
+    const result = await runCli(
+      [
+        'sync',
+        'schema',
+        '--source',
+        sourceUrl(),
+        '--target',
+        `${targetUrl()}?token=url-token`,
+      ],
+      { cwd: workspace, env },
+    );
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/e2e/matrix/M10-sync.e2e-spec.ts
+++ b/e2e/matrix/M10-sync.e2e-spec.ts
@@ -83,7 +83,10 @@ describe('M10 — sync', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await Promise.all([source.stop(), target.stop()]);
+    await Promise.all([
+      source ? source.stop() : Promise.resolve(),
+      target ? target.stop() : Promise.resolve(),
+    ]);
   });
 
   function setup(): { workspace: string; env: Record<string, string> } {
@@ -128,7 +131,7 @@ describe('M10 — sync', () => {
 
   it('sync data copies rows once schemas match', async () => {
     const { workspace, env } = setup();
-    await runCli(
+    const schema = await runCli(
       [
         'sync',
         'schema',
@@ -140,6 +143,7 @@ describe('M10 — sync', () => {
       ],
       { cwd: workspace, env, timeout: 240_000 },
     );
+    expect(schema.exitCode).toBe(0);
     const result = await runCli(
       [
         'sync',
@@ -153,6 +157,19 @@ describe('M10 — sync', () => {
       { cwd: workspace, env, timeout: 240_000 },
     );
     expect(result.exitCode).toBe(0);
+
+    const tagRowsCopied = await target.api.listRows(
+      'admin',
+      targetProject,
+      'Tag',
+    );
+    const questRowsCopied = await target.api.listRows(
+      'admin',
+      targetProject,
+      'Quest',
+    );
+    expect(tagRowsCopied).toHaveLength(3);
+    expect(questRowsCopied).toHaveLength(5);
   });
 
   it('sync all --commit performs schema + data in one shot', async () => {
@@ -175,6 +192,10 @@ describe('M10 — sync', () => {
     expect(result.exitCode).toBe(0);
     const targetTables = await target.api.listTables('admin', fresh);
     expect(targetTables.map((t) => t.id).sort()).toEqual(['Quest', 'Tag']);
+    const tagRowsCopied = await target.api.listRows('admin', fresh, 'Tag');
+    const questRowsCopied = await target.api.listRows('admin', fresh, 'Quest');
+    expect(tagRowsCopied).toHaveLength(3);
+    expect(questRowsCopied).toHaveLength(5);
   });
 
   it('rejects mutually-exclusive auth: both ?token=... and REVISIUM_TARGET_TOKEN', async () => {

--- a/e2e/matrix/M10-sync.e2e-spec.ts
+++ b/e2e/matrix/M10-sync.e2e-spec.ts
@@ -217,5 +217,8 @@ describe('M10 — sync', () => {
       { cwd: workspace, env },
     );
     expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toLowerCase()).toMatch(
+      /(mutually[- ]exclusive|conflict|both.*token)/,
+    );
   });
 });

--- a/e2e/matrix/M11-target-resolution.e2e-spec.ts
+++ b/e2e/matrix/M11-target-resolution.e2e-spec.ts
@@ -43,7 +43,9 @@ describe('M11 — target & auth resolution', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function buildWorkspace(currentContext: string): string {

--- a/e2e/matrix/M11-target-resolution.e2e-spec.ts
+++ b/e2e/matrix/M11-target-resolution.e2e-spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Matrix M11 — Target / auth resolution precedence on a single command
+ * (`project ensure`).
+ *
+ * Standalone: one `--auth` instance.
+ *
+ * Prep:
+ *  1. Spawn standalone, login, mint API key.
+ *  2. Workspace tempdir gets a config with two contexts and one
+ *     `currentContext`.
+ *  3. Project is created lazily per case so tests don't depend on each other.
+ */
+
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  writeWorkspaceConfig,
+} from '../utils/matrix-workspace';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M11 — target & auth resolution', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  let adminToken: string;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    adminToken = await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'matrix-resolution' })
+    ).apiKey;
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function buildWorkspace(currentContext: string): string {
+    const workspace = createWorkspace('revisium-cli-matrix-resolution-');
+    workspaces.push(workspace);
+    writeWorkspaceConfig(workspace, {
+      currentContext,
+      instances: { local: { baseUrl: standalone.baseUrl, authMode: 'stored' } },
+      contexts: {
+        primary: {
+          instance: 'local',
+          organization: 'admin',
+          project: 'project-primary',
+        },
+        secondary: {
+          instance: 'local',
+          organization: 'admin',
+          project: 'project-secondary',
+        },
+      },
+    });
+    return workspace;
+  }
+
+  it('--url overrides --context', async () => {
+    const workspace = buildWorkspace('primary');
+    const projectFromUrl = `m11-url-${Date.now()}`;
+    const result = await runCli(
+      [
+        'project',
+        'ensure',
+        '--context',
+        'primary',
+        '--url',
+        standalone.url({ project: projectFromUrl }),
+        '--json',
+      ],
+      {
+        cwd: workspace,
+        env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey },
+      },
+    );
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as { project: string };
+    expect(summary.project).toBe(projectFromUrl);
+  });
+
+  it('--context overrides REVISIUM_URL', async () => {
+    const workspace = buildWorkspace('primary');
+    const result = await runCli(
+      ['project', 'ensure', '--context', 'secondary', '--json'],
+      {
+        cwd: workspace,
+        env: {
+          ...CLEAR_REVISIUM_ENV,
+          REVISIUM_URL: standalone.url({ project: 'project-from-env' }),
+          REVISIUM_API_KEY: apiKey,
+        },
+      },
+    );
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as { project: string };
+    expect(summary.project).toBe('project-secondary');
+  });
+
+  it('REVISIUM_URL overrides currentContext', async () => {
+    const workspace = buildWorkspace('primary');
+    const result = await runCli(['project', 'ensure', '--json'], {
+      cwd: workspace,
+      env: {
+        ...CLEAR_REVISIUM_ENV,
+        REVISIUM_URL: standalone.url({ project: 'project-from-env' }),
+        REVISIUM_API_KEY: apiKey,
+      },
+    });
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as { project: string };
+    expect(summary.project).toBe('project-from-env');
+  });
+
+  it('falls back to currentContext when nothing else is set', async () => {
+    const workspace = buildWorkspace('secondary');
+    const result = await runCli(['project', 'ensure', '--json'], {
+      cwd: workspace,
+      env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey },
+    });
+    expect(result.exitCode).toBe(0);
+    const summary = JSON.parse(result.stdout) as { project: string };
+    expect(summary.project).toBe('project-secondary');
+  });
+
+  it('--token overrides REVISIUM_API_KEY', async () => {
+    const workspace = buildWorkspace('primary');
+    const project = `m11-token-${Date.now()}`;
+    const result = await runCli(
+      [
+        'project',
+        'ensure',
+        '--url',
+        standalone.url({ project }),
+        '--token',
+        adminToken,
+      ],
+      {
+        cwd: workspace,
+        env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: 'wrong-key' },
+      },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('?token=... in URL overrides REVISIUM_TOKEN', async () => {
+    const workspace = buildWorkspace('primary');
+    const project = `m11-url-token-${Date.now()}`;
+    const result = await runCli(
+      [
+        'project',
+        'ensure',
+        '--url',
+        `${standalone.url({ project })}?token=${adminToken}`,
+      ],
+      {
+        cwd: workspace,
+        env: { ...CLEAR_REVISIUM_ENV, REVISIUM_TOKEN: 'wrong-token' },
+      },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/e2e/matrix/M12-error-paths.e2e-spec.ts
+++ b/e2e/matrix/M12-error-paths.e2e-spec.ts
@@ -41,7 +41,9 @@ describe('M12 — error paths', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function newWorkspace(): string {
@@ -72,6 +74,9 @@ describe('M12 — error paths', () => {
       },
     );
     expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toLowerCase()).toMatch(
+      /unauthorized|forbidden|invalid|credential|api key|401|403/,
+    );
   });
 
   it('broken workspace config surfaces a parse error with the file path', async () => {

--- a/e2e/matrix/M12-error-paths.e2e-spec.ts
+++ b/e2e/matrix/M12-error-paths.e2e-spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Matrix M12 — Error paths and remediation messages.
+ *
+ * Standalone: one `--auth` instance.
+ *
+ * Prep: spawn standalone, login, mint a key. Tests deliberately send the
+ * wrong credentials, missing files, malformed config, etc., and assert on
+ * non-zero exit codes + helpful stderr.
+ */
+
+import * as fs from 'node:fs';
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  writeWorkspaceConfig,
+  workspaceFile,
+} from '../utils/matrix-workspace';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M12 — error paths', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin',
+    });
+    await standalone.api.login('admin', 'test-admin');
+    apiKey = (
+      await standalone.api.mintApiKey('admin', { name: 'matrix-errors' })
+    ).apiKey;
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function newWorkspace(): string {
+    const ws = createWorkspace('revisium-cli-matrix-errors-');
+    workspaces.push(ws);
+    return ws;
+  }
+
+  it('unauthenticated request to --auth standalone surfaces an auth error', async () => {
+    const workspace = newWorkspace();
+    const result = await runCli(
+      ['project', 'ensure', '--url', standalone.url({ project: 'whatever' })],
+      { cwd: workspace, env: { ...CLEAR_REVISIUM_ENV } },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toLowerCase()).toMatch(
+      /auth|credential|unauthorized|api key|401/,
+    );
+  });
+
+  it('wrong API key surfaces a credential error', async () => {
+    const workspace = newWorkspace();
+    const result = await runCli(
+      ['project', 'ensure', '--url', standalone.url({ project: 'whatever' })],
+      {
+        cwd: workspace,
+        env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: 'invalid-key' },
+      },
+    );
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('broken workspace config surfaces a parse error with the file path', async () => {
+    const workspace = newWorkspace();
+    const path = workspaceFile(
+      workspace,
+      '.revisium',
+      'revisium-cli.config.json',
+    );
+    fs.mkdirSync(workspaceFile(workspace, '.revisium'), { recursive: true });
+    fs.writeFileSync(path, '{ broken json');
+    const result = await runCli(['instance', 'list'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('revisium-cli.config.json');
+  });
+
+  it('instance remove against an unknown name fails fast', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, { instances: {} });
+    const result = await runCli(['instance', 'remove', 'unknown'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('context use against an unknown name fails fast', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      instances: { local: { baseUrl: standalone.baseUrl } },
+      contexts: {},
+    });
+    const result = await runCli(['context', 'use', 'unknown'], {
+      cwd: workspace,
+      env: CLEAR_REVISIUM_ENV,
+    });
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('migrate apply with a missing file surfaces ENOENT-like error', async () => {
+    const workspace = newWorkspace();
+    const result = await runCli(
+      [
+        'migrate',
+        'apply',
+        '--file',
+        workspaceFile(workspace, 'absent.json'),
+        '--commit',
+        '--url',
+        standalone.url({ project: 'whatever' }),
+      ],
+      {
+        cwd: workspace,
+        env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey },
+      },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toLowerCase()).toMatch(/file|not found|enoent/);
+  });
+
+  it('example bootstrap with a missing config fails before contacting the server', async () => {
+    const workspace = newWorkspace();
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        workspaceFile(workspace, 'absent.json'),
+        '--url',
+        standalone.url({ project: 'whatever' }),
+      ],
+      {
+        cwd: workspace,
+        env: { ...CLEAR_REVISIUM_ENV, REVISIUM_API_KEY: apiKey },
+      },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/Could not read bootstrap config/);
+  });
+});

--- a/e2e/matrix/M13-no-auth-mode.e2e-spec.ts
+++ b/e2e/matrix/M13-no-auth-mode.e2e-spec.ts
@@ -34,7 +34,9 @@ describe('M13 — authMode none', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await standalone.stop();
+    if (standalone) {
+      await standalone.stop();
+    }
   });
 
   function newWorkspace(): string {

--- a/e2e/matrix/M13-no-auth-mode.e2e-spec.ts
+++ b/e2e/matrix/M13-no-auth-mode.e2e-spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Matrix M13 — `authMode: "none"` flow against an unauthenticated standalone.
+ *
+ * Standalone: one instance WITHOUT `--auth`.
+ *
+ * Prep:
+ *  1. Spawn standalone without --auth (no admin credentials needed).
+ *  2. Use REST API directly to create projects (no auth required).
+ *  3. Per-test workspace tempdir.
+ */
+
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  uniqueCredentialStoreService,
+  writeWorkspaceConfig,
+} from '../utils/matrix-workspace';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M13 — authMode none', () => {
+  let standalone: StandaloneInstance;
+  const credentialStoreService = uniqueCredentialStoreService();
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    standalone = await startStandalone({ auth: false });
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await standalone.stop();
+  });
+
+  function newWorkspace(): string {
+    const ws = createWorkspace('revisium-cli-matrix-noauth-');
+    workspaces.push(ws);
+    return ws;
+  }
+
+  function buildEnv(): Record<string, string> {
+    return {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_CREDENTIAL_STORE_SERVICE: credentialStoreService,
+    };
+  }
+
+  it('project ensure works against an authMode "none" instance without credentials', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      currentContext: 'local-default',
+      instances: { local: { baseUrl: standalone.baseUrl, authMode: 'none' } },
+      contexts: {
+        'local-default': {
+          instance: 'local',
+          organization: 'admin',
+          project: `m13-${Date.now()}`,
+        },
+      },
+    });
+    const result = await runCli(['project', 'ensure', '--json'], {
+      cwd: workspace,
+      env: buildEnv(),
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('auth login refuses to save a credential for authMode "none" without --force', async () => {
+    const workspace = newWorkspace();
+    writeWorkspaceConfig(workspace, {
+      instances: { local: { baseUrl: standalone.baseUrl, authMode: 'none' } },
+    });
+    const result = await runCli(
+      ['auth', 'login', '--instance', 'local', '--api-key-stdin'],
+      { cwd: workspace, env: buildEnv(), stdin: 'rev_dummy\n' },
+    );
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('example bootstrap works without any credential', async () => {
+    const workspace = newWorkspace();
+    const project = `m13-bootstrap-${Date.now()}`;
+    writeWorkspaceConfig(workspace, {
+      currentContext: 'local-default',
+      instances: { local: { baseUrl: standalone.baseUrl, authMode: 'none' } },
+      contexts: {
+        'local-default': {
+          instance: 'local',
+          organization: 'admin',
+          project,
+        },
+      },
+    });
+    const configPath = `${workspace}/bootstrap.config.json`;
+    const fs = await import('node:fs');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        projectName: project,
+        endpoints: ['REST_API'],
+        tables: [],
+        rows: [],
+      }),
+      'utf-8',
+    );
+    const result = await runCli(
+      ['example', 'bootstrap', '--config', configPath, '--json'],
+      { cwd: workspace, env: buildEnv(), timeout: 120_000 },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/e2e/matrix/M14-multi-instance-workspace.e2e-spec.ts
+++ b/e2e/matrix/M14-multi-instance-workspace.e2e-spec.ts
@@ -89,34 +89,53 @@ describe('M14 — multi-instance workspace', () => {
 
   it('saves independent credentials per instance', async () => {
     const { workspace, env } = setup();
-    await runCli(
+    const loginPrimary = await runCli(
       ['auth', 'login', '--instance', 'primary', '--api-key-stdin'],
-      {
-        cwd: workspace,
-        env,
-        stdin: primaryKey + '\n',
-      },
+      { cwd: workspace, env, stdin: primaryKey + '\n' },
     );
-    await runCli(
+    expect(loginPrimary.exitCode).toBe(0);
+    const loginSecondary = await runCli(
       ['auth', 'login', '--instance', 'secondary', '--api-key-stdin'],
-      {
-        cwd: workspace,
-        env,
-        stdin: secondaryKey + '\n',
-      },
+      { cwd: workspace, env, stdin: secondaryKey + '\n' },
     );
+    expect(loginSecondary.exitCode).toBe(0);
 
     const primaryStatus = await runCli(
       ['auth', 'status', '--instance', 'primary'],
       { cwd: workspace, env },
     );
+    expect(primaryStatus.exitCode).toBe(0);
     expect(primaryStatus.stdout).toContain('Saved credential found');
 
     const secondaryStatus = await runCli(
       ['auth', 'status', '--instance', 'secondary'],
       { cwd: workspace, env },
     );
+    expect(secondaryStatus.exitCode).toBe(0);
     expect(secondaryStatus.stdout).toContain('Saved credential found');
+
+    // Independence: each instance points at its own baseUrl, so the two
+    // status outputs should differ on the host portion. Removing one
+    // credential must not affect the other.
+    expect(primaryStatus.stdout).not.toEqual(secondaryStatus.stdout);
+
+    const logoutPrimary = await runCli(
+      ['auth', 'logout', '--instance', 'primary'],
+      { cwd: workspace, env },
+    );
+    expect(logoutPrimary.exitCode).toBe(0);
+
+    const primaryAfter = await runCli(
+      ['auth', 'status', '--instance', 'primary'],
+      { cwd: workspace, env },
+    );
+    expect(primaryAfter.stdout).toContain('No saved credential found');
+
+    const secondaryAfter = await runCli(
+      ['auth', 'status', '--instance', 'secondary'],
+      { cwd: workspace, env },
+    );
+    expect(secondaryAfter.stdout).toContain('Saved credential found');
   });
 
   it('context switching flips the target between instances', async () => {

--- a/e2e/matrix/M14-multi-instance-workspace.e2e-spec.ts
+++ b/e2e/matrix/M14-multi-instance-workspace.e2e-spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Matrix M14 — Two standalone instances driven from a single workspace.
+ *
+ * Prep:
+ *  1. Spawn `primary` and `secondary` standalone instances, both `--auth`.
+ *  2. Login + mint API key on each; per-suite credential-store service so
+ *     saved creds for `primary` and `secondary` are isolated from the host
+ *     keyring.
+ *  3. Workspace tempdir holds two instances + two contexts (one per).
+ */
+
+import { runCli } from '../utils/cli-runner';
+import {
+  CLEAR_REVISIUM_ENV,
+  createWorkspace,
+  removeWorkspace,
+  uniqueCredentialStoreService,
+  writeWorkspaceConfig,
+} from '../utils/matrix-workspace';
+import {
+  startStandalone,
+  StandaloneInstance,
+} from '../utils/standalone-runner';
+
+describe('M14 — multi-instance workspace', () => {
+  let primary: StandaloneInstance;
+  let secondary: StandaloneInstance;
+  let primaryKey: string;
+  let secondaryKey: string;
+  const credentialStoreService = uniqueCredentialStoreService();
+  const workspaces: string[] = [];
+
+  beforeAll(async () => {
+    primary = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin-primary',
+    });
+    secondary = await startStandalone({
+      auth: true,
+      adminPassword: 'test-admin-secondary',
+    });
+
+    await primary.api.login('admin', 'test-admin-primary');
+    await secondary.api.login('admin', 'test-admin-secondary');
+    primaryKey = (
+      await primary.api.mintApiKey('admin', { name: 'matrix-primary' })
+    ).apiKey;
+    secondaryKey = (
+      await secondary.api.mintApiKey('admin', { name: 'matrix-secondary' })
+    ).apiKey;
+  }, 360_000);
+
+  afterAll(async () => {
+    for (const workspace of workspaces) removeWorkspace(workspace);
+    workspaces.length = 0;
+    await Promise.all([primary.stop(), secondary.stop()]);
+  });
+
+  function setup(): { workspace: string; env: Record<string, string> } {
+    const workspace = createWorkspace('revisium-cli-matrix-multi-');
+    workspaces.push(workspace);
+    writeWorkspaceConfig(workspace, {
+      instances: {
+        primary: { baseUrl: primary.baseUrl, authMode: 'stored' },
+        secondary: { baseUrl: secondary.baseUrl, authMode: 'stored' },
+      },
+      contexts: {
+        'primary-default': {
+          instance: 'primary',
+          organization: 'admin',
+          project: 'p',
+        },
+        'secondary-default': {
+          instance: 'secondary',
+          organization: 'admin',
+          project: 's',
+        },
+      },
+    });
+    const env: Record<string, string> = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_CREDENTIAL_STORE_SERVICE: credentialStoreService,
+    };
+    return { workspace, env };
+  }
+
+  it('saves independent credentials per instance', async () => {
+    const { workspace, env } = setup();
+    await runCli(
+      ['auth', 'login', '--instance', 'primary', '--api-key-stdin'],
+      {
+        cwd: workspace,
+        env,
+        stdin: primaryKey + '\n',
+      },
+    );
+    await runCli(
+      ['auth', 'login', '--instance', 'secondary', '--api-key-stdin'],
+      {
+        cwd: workspace,
+        env,
+        stdin: secondaryKey + '\n',
+      },
+    );
+
+    const primaryStatus = await runCli(
+      ['auth', 'status', '--instance', 'primary'],
+      { cwd: workspace, env },
+    );
+    expect(primaryStatus.stdout).toContain('Saved credential found');
+
+    const secondaryStatus = await runCli(
+      ['auth', 'status', '--instance', 'secondary'],
+      { cwd: workspace, env },
+    );
+    expect(secondaryStatus.stdout).toContain('Saved credential found');
+  });
+
+  it('context switching flips the target between instances', async () => {
+    const { workspace, env } = setup();
+    await runCli(
+      ['auth', 'login', '--instance', 'primary', '--api-key-stdin'],
+      {
+        cwd: workspace,
+        env,
+        stdin: primaryKey + '\n',
+      },
+    );
+    await runCli(
+      ['auth', 'login', '--instance', 'secondary', '--api-key-stdin'],
+      {
+        cwd: workspace,
+        env,
+        stdin: secondaryKey + '\n',
+      },
+    );
+
+    await runCli(['context', 'use', 'primary-default'], {
+      cwd: workspace,
+      env,
+    });
+    const primaryEnsure = await runCli(['project', 'ensure', '--json'], {
+      cwd: workspace,
+      env,
+    });
+    expect(primaryEnsure.exitCode).toBe(0);
+    expect(await primary.api.projectExists('admin', 'p')).toBe(true);
+
+    await runCli(['context', 'use', 'secondary-default'], {
+      cwd: workspace,
+      env,
+    });
+    const secondaryEnsure = await runCli(['project', 'ensure', '--json'], {
+      cwd: workspace,
+      env,
+    });
+    expect(secondaryEnsure.exitCode).toBe(0);
+    expect(await secondary.api.projectExists('admin', 's')).toBe(true);
+  });
+});

--- a/e2e/matrix/M14-multi-instance-workspace.e2e-spec.ts
+++ b/e2e/matrix/M14-multi-instance-workspace.e2e-spec.ts
@@ -53,7 +53,10 @@ describe('M14 — multi-instance workspace', () => {
   afterAll(async () => {
     for (const workspace of workspaces) removeWorkspace(workspace);
     workspaces.length = 0;
-    await Promise.all([primary.stop(), secondary.stop()]);
+    await Promise.all([
+      primary ? primary.stop() : Promise.resolve(),
+      secondary ? secondary.stop() : Promise.resolve(),
+    ]);
   });
 
   function setup(): { workspace: string; env: Record<string, string> } {

--- a/e2e/matrix/README.md
+++ b/e2e/matrix/README.md
@@ -1,0 +1,354 @@
+# Revisium CLI E2E Matrix
+
+Status: Authoring — tests will be exercised against the alpha `revisium-cli` release paired with stable `@revisium/standalone`.
+
+## Goal
+
+Drive every `revisium-cli` command and resolution path against a real `@revisium/standalone` instance, so we catch regressions in:
+
+- argument parsing and subcommand dispatch
+- target resolution (`--url`, `--context`, env, workspace, URL auth)
+- authentication (token, API key, password, saved API key, no-auth)
+- idempotency (project / endpoint / table / row / endpoint ensure)
+- output formats (`--json`, human, `--dry-run`)
+- conflict and error paths (schema mismatch, row mismatch, invalid configs, non-draft target)
+- cross-instance flows (`sync schema/data/all`)
+
+Each suite spins up a **fresh standalone** in a temp data directory, prepares its own auth + fixtures via the standalone REST/GraphQL API, runs the CLI binary, and tears down.
+
+## Runtime contract
+
+- Each `.e2e-spec.ts` file under `e2e/matrix/` owns its standalone instance(s).
+- A standalone starts on a random free port, with `--data <tempDir>`, optional `--auth`, optional `ADMIN_PASSWORD`.
+- After the suite, `afterAll` stops the process and removes the temp dir.
+- The CLI binary is the one in `dist/src/main.js` (`E2E_INSTRUMENTED=1` swaps to `dist-instrumented/...` for coverage).
+- `runCli(args, { cwd, env })` from `e2e/utils/cli-runner.ts` is the single way to invoke the CLI; tests must clear `REVISIUM_*` env vars they don't need (see `CLEAR_REVISIUM_ENV`).
+- `cwd` is always a fresh per-test workspace tempdir, so `.revisium/revisium-cli.config.json` doesn't bleed across tests.
+- Saved API-key credentials use a per-test `REVISIUM_CREDENTIAL_STORE_SERVICE` namespace so OS keyring entries don't bleed.
+
+## Matrix axes
+
+### Auth modes
+
+| ID                    | Standalone flag      | Prep steps                                                                                                         |
+| --------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **AUTH-NONE**         | _no `--auth`_        | start standalone; CLI talks to it without credentials                                                              |
+| **AUTH-TOKEN**        | `--auth`             | log in as admin (`ADMIN_PASSWORD`); use returned JWT as `--token`/`REVISIUM_TOKEN`                                 |
+| **AUTH-APIKEY**       | `--auth`             | login → mint org-scoped API key via `POST /api/api-keys`; use as `--api-key`/`REVISIUM_API_KEY`                    |
+| **AUTH-PASSWORD**     | `--auth`             | use `REVISIUM_USERNAME` / `REVISIUM_PASSWORD` env (or `user:pass@host` URL form)                                   |
+| **AUTH-STORED**       | `--auth`             | `revisium auth login --api-key-stdin` saves to OS keyring under per-test service name; subsequent commands resolve |
+| **AUTH-URL-TOKEN**    | `--auth`             | embed `?token=...` in URL                                                                                          |
+| **AUTH-URL-APIKEY**   | `--auth`             | embed `?apikey=...` in URL                                                                                         |
+| **AUTH-URL-PASSWORD** | `--auth`             | embed `user:pass@host` in URL                                                                                      |
+
+### Target resolution
+
+| ID                    | Carrier                                                                       |
+| --------------------- | ----------------------------------------------------------------------------- |
+| **TARGET-URL**        | `--url revisium://host/org/proj/branch[:rev]`                                 |
+| **TARGET-CONTEXT**    | `--context <name>` against an existing workspace `revisium-cli.config.json`   |
+| **TARGET-CURRENT**    | `currentContext` resolved from the workspace config                           |
+| **TARGET-ENV-URL**    | `REVISIUM_URL` env var                                                        |
+| **TARGET-ENV-PARTS**  | `REVISIUM_HOST` / `REVISIUM_ORG` / `REVISIUM_PROJECT` / `REVISIUM_BRANCH`     |
+| **TARGET-INSTANCE**   | command takes `--instance` (auth commands) and resolves via workspace config  |
+| **TARGET-MIXED**      | precedence: explicit flag > URL auth > env > workspace > interactive (denied) |
+
+### Output / behaviour flags
+
+`--json`, `--dry-run`, `--commit`, `--quiet` (where supported), repeated `--endpoint`, `--no-input` (when wired).
+
+---
+
+## Suites
+
+Each row below is implemented as one `*.e2e-spec.ts` file in `e2e/matrix/`. The "Prep" column lists the deterministic steps each `beforeAll` / `beforeEach` performs against the standalone REST API.
+
+### M01-auth-commands
+
+**Files:** `M01-auth-commands.e2e-spec.ts`
+**Standalone:** one instance, `--auth`
+**Prep:**
+
+1. Start standalone with `ADMIN_PASSWORD=test-admin` and `--auth`.
+2. Wait for `/health/readiness`.
+3. `POST /api/auth/login` with admin credentials → store JWT.
+4. Mint two API keys: `default` and `automation` via `POST /api/organizations/admin/api-keys` (one expires soon, one long-lived).
+5. Pick a per-suite `REVISIUM_CREDENTIAL_STORE_SERVICE` so saved keys don't collide with the user's keyring.
+
+**Cases (AUTH-STORED axis):**
+
+- `auth login --url <baseUrl> --api-key` (interactive prompt mocked via `--api-key-stdin`).
+- `auth login --instance <name>` after `instance add`.
+- `auth login --credential <name>` saves under that name.
+- `auth login --force` overrides existing entry.
+- `auth login` against `authMode: "none"` rejects without `--force`.
+- `auth status` for stored credential reports OK; against missing credential prints login hint.
+- `auth status` for `authMode: "none"` instance prints "bypassed" message.
+- `auth logout --instance` removes the saved credential.
+- `auth logout --credential <name>` removes a specific credential.
+- Logging in twice with different `--credential` values lets `auth status --credential` distinguish them.
+
+### M02-instance-commands
+
+**Files:** `M02-instance-commands.e2e-spec.ts`
+**Standalone:** one instance, `--auth` (commands are workspace-only, but a real baseUrl is needed for URL normalization).
+**Prep:** start standalone; obtain its baseUrl.
+**Cases:**
+
+- `instance add <name> --url revisium://host:port` writes workspace config.
+- `instance add` accepts full `revisium://host/org/project/branch` and stores only the server location.
+- `instance add --auth none` and `--auth stored` (default) round-trip through `instance show`.
+- `instance list` after multiple adds returns sorted list.
+- `instance remove <name>` removes; `--with-credentials` also clears the saved credential (verified via `auth status`).
+- Re-adding an existing instance without `--force` errors.
+
+### M03-context-commands
+
+**Files:** `M03-context-commands.e2e-spec.ts`
+**Standalone:** one instance, `--auth`.
+**Prep:**
+
+1. Start standalone, log in, mint API key.
+2. Seed two projects `dictionary` and `taxonomy` via REST.
+3. Create instance `local` in workspace.
+**Cases:**
+
+- `context create dictionary-local --instance local --org admin --project dictionary` writes config.
+- `context create from-url --url revisium://host/admin/dictionary/master:draft` parses parts.
+- Mutating commands reject `head` / non-draft revision.
+- `context list` / `context show` / `context use dictionary-local` round-trip.
+- `context use taxonomy-local` updates `currentContext`.
+- `context remove dictionary-local` removes; `currentContext` cleared when it was the active one.
+
+### M04-project-ensure
+
+**Files:** `M04-project-ensure.e2e-spec.ts`
+**Standalone:** `--auth`, `AUTH-APIKEY`.
+**Prep:** start standalone, log in, mint API key, no projects yet.
+**Cases (×each TARGET axis):**
+
+- Fresh project → `project ensure --url <revisium-url>` creates project + master branch (`projectStatus: created`, `branchStatus: created`).
+- Re-run → `projectStatus: skipped` / `branchStatus: skipped`.
+- `--dry-run` → reports `created` but standalone GraphQL still 404s on the project.
+- Non-default branch (`/master/feature`) → re-run after ensure shows branch was created from rootBranch head.
+- `--json` payload matches `ProjectEnsureResult` shape exactly.
+- Auth precedence: `--token <X>` overrides `REVISIUM_API_KEY`; URL `?token=` overrides env.
+- Stored credential path: `auth login` then `project ensure --instance local` works without `--token`/`--api-key`.
+
+### M05-endpoint-commands
+
+**Files:** `M05-endpoint-commands.e2e-spec.ts`
+**Standalone:** `--auth`, `AUTH-APIKEY`.
+**Prep:**
+
+1. Start standalone, log in, mint API key.
+2. Seed project `dictionary` with master branch.
+3. Bootstrap a single table `Tag` so the draft revision is non-empty.
+**Cases:**
+
+- `endpoint ensure --type REST_API` first run → `Created`; second run → `Found`; `--dry-run` does not create.
+- `endpoint ensure --type GRAPHQL` independent of REST_API.
+- `endpoint ensure --type INVALID` rejects with `parseEndpointType` error.
+- `endpoint list` returns both endpoints once created; `--json` returns `{ endpoints: [...] }`.
+- `endpoint list` against a freshly-bootstrapped project with no endpoints returns "No generated endpoints found" / `{ endpoints: [] }`.
+
+### M06-example-bootstrap
+
+**Files:** `M06-example-bootstrap.e2e-spec.ts`
+**Standalone:** `--auth`, `AUTH-APIKEY`.
+**Prep:**
+
+1. Start standalone, log in, mint API key.
+2. For each test, write a fresh `bootstrap.config.json` into a workspace tempdir using `matrix-fixtures.ts` builders (`tagsFixture()`, `faqFixture()`, etc.).
+**Cases:**
+
+- Empty target → all created; second run → all skipped (idempotent).
+- `--commit` creates a revision; revision id appears in `summary.commit.revisionId`.
+- `--dry-run` reports created counts without writing — verified by calling REST API to confirm the project still has no `Tag` table.
+- `--dry-run` against a project that has the rootBranch already populated diffs against root head and reports `skipped` for inherited resources (regression test for the issue fixed in #73 review round).
+- `--endpoint REST_API --endpoint GRAPHQL` overrides `endpoints` from config.
+- Schema conflict: pre-seed table `Tag` with a different schema; bootstrap rejects with `Bootstrap table conflict: Tag: existing table schema differs ...` and writes nothing.
+- Row conflict: pre-seed row with different data; bootstrap rejects with `Bootstrap row conflict: ...`.
+- `projectName` mismatch in config rejects before any creation.
+- `branchName` mismatch in config rejects before any creation.
+- Non-draft revision (`master:head`) rejects with `requires a draft revision` and creates nothing (regression for the issue fixed in #73 review round).
+- Invalid config: empty file, non-object root, wrong types per field, missing fields, non-string endpoints → each rejects with the specific validation message.
+- `--json` output schema matches `ExampleBootstrapSummary`.
+
+### M07-migrate
+
+**Files:** `M07-migrate.e2e-spec.ts`
+**Standalone:** `--auth`, `AUTH-APIKEY`.
+**Prep:**
+
+1. Start standalone, log in, mint API key, seed source project with `Tag` table + 3 rows.
+2. Pre-build expected migration JSON via `matrix-fixtures.tagMigration()`.
+**Cases:**
+
+- `migrate save --file ./out.json --url <source>` exports a migration JSON; deep-equals the fixture.
+- `migrate apply --file ./out.json --commit --url <empty target>` creates the table; revision committed.
+- Re-applying the same migration is a no-op (idempotent).
+- `migrate apply --create-project` against missing project creates it before applying.
+- `migrate apply` against `master:head` without `--commit` rejects (writes need draft).
+
+### M08-schema
+
+**Files:** `M08-schema.e2e-spec.ts`
+**Standalone:** `--auth`, `AUTH-APIKEY`.
+**Prep:** seed project with three tables.
+**Cases:**
+
+- `schema save --folder ./schemas` writes one JSON per table; schemas match REST output.
+- `schema create-migrations --folder ./schemas --output ./out.json` is offline (no network) and produces a deep-equal migration.
+- Round-trip: `schema save` → `schema create-migrations` → `migrate apply` results in identical schemas in target.
+
+### M09-rows
+
+**Files:** `M09-rows.e2e-spec.ts`
+**Standalone:** `--auth`, `AUTH-APIKEY`.
+**Prep:** seed project with table `Quest` + 50 rows (uses `matrix-fixtures.questsFixture(50)`).
+**Cases:**
+
+- `rows save --folder ./data` writes one file per table containing all rows.
+- `rows upload --folder ./data --commit` against an empty target imports them; row count matches via REST.
+- Batch size flag (`--batch <n>`) honoured; verified by intercepting CLI logs.
+- Foreign-key dependency ordering: tables with refs imported in the right order (smoke test for `TableDependencyService`).
+
+### M10-sync
+
+**Files:** `M10-sync.e2e-spec.ts`
+**Standalone:** **two** instances (source + target), both `--auth`.
+**Prep:**
+
+1. Start standalone-source on port A, target on port B.
+2. Mint API keys on each, expose as `REVISIUM_SOURCE_API_KEY` / `REVISIUM_TARGET_API_KEY`.
+3. Seed source project with schema + rows; create empty target project.
+**Cases:**
+
+- `sync schema --source ... --target ...` copies tables.
+- `sync data --source ... --target ...` copies rows.
+- `sync all --commit` performs both; final REST diff is empty.
+- `sync all` honours `REVISIUM_SOURCE_*` / `REVISIUM_TARGET_*` env vars (no `?apikey=` in the URL).
+- Source `:head` fixed-revision mode produces consistent target.
+- Mutually-exclusive auth (e.g. both `?token=` and `REVISIUM_TARGET_TOKEN`) is rejected with a clear conflict message.
+
+### M11-target-resolution
+
+**Files:** `M11-target-resolution.e2e-spec.ts`
+**Standalone:** one instance, `--auth`.
+**Prep:** seed project, mint key, write workspace config with two contexts.
+**Cases (single, well-known command — `project ensure`):**
+
+- `--url` wins over `--context` and over `REVISIUM_URL`.
+- `--context` wins over `REVISIUM_URL` and over `currentContext`.
+- `REVISIUM_URL` wins over workspace `currentContext`.
+- `currentContext` resolves the target when nothing else is set.
+- No target + `--no-input`-equivalent (CI tty heuristics) → fails fast.
+- URL credential precedence: `--token` overrides `?token=` overrides `REVISIUM_TOKEN`.
+
+### M12-error-paths
+
+**Files:** `M12-error-paths.e2e-spec.ts`
+**Standalone:** one instance, `--auth`.
+**Cases:**
+
+- Unauthenticated request to `--auth` standalone returns "auth required" with login hint.
+- Wrong API key returns 401 surfaced with "invalid credential" hint.
+- Workspace config with broken JSON → CLI prints clear path + parse error.
+- `instance remove` of unknown name fails fast.
+- `context use` of unknown name fails fast.
+- `migrate apply --file <missing>` fails with file-read error including the path.
+- `example bootstrap --config <missing>` fails before contacting the server.
+
+### M13-no-auth-mode
+
+**Files:** `M13-no-auth-mode.e2e-spec.ts`
+**Standalone:** **without** `--auth`.
+**Prep:** start standalone (no auth), seed project via REST.
+**Cases:**
+
+- `instance add local --url <baseUrl> --auth none` then `project ensure --instance local` works without any credential.
+- `auth login --instance local` rejected unless `--force`.
+- `example bootstrap` works unauthenticated.
+
+### M14-multi-instance-workspace
+
+**Files:** `M14-multi-instance-workspace.e2e-spec.ts`
+**Standalone:** **two** instances (`primary`, `secondary`), both `--auth`.
+**Prep:**
+
+1. Start both standalone instances.
+2. Mint API key on each.
+3. Workspace config has both as instances + one context per.
+**Cases:**
+
+- `auth login --instance primary` and `--instance secondary` save independent credentials.
+- `context use primary-default` then `project ensure` targets primary; `context use secondary-default` flips it.
+- `auth status --instance secondary` does not see primary's credential.
+
+---
+
+## Helper layout
+
+```
+e2e/utils/
+  standalone-runner.ts   — spawns @revisium/standalone, waits for /health/readiness, returns { baseUrl, adminToken, stop() }
+  standalone-api.ts      — REST/GraphQL helpers: login, mintApiKey, createProject, seedTable, seedRows, getEndpoints, getRows
+  matrix-fixtures.ts     — pure fixture builders (tagSchema, faqSchema, questsRows, bootstrapConfig)
+  matrix-workspace.ts    — tempdir + workspace-config helpers (writeConfig, withCredentialStoreNamespace)
+e2e/matrix/
+  README.md              — this file
+  M01-auth-commands.e2e-spec.ts
+  M02-instance-commands.e2e-spec.ts
+  ...
+  M14-multi-instance-workspace.e2e-spec.ts
+```
+
+## Per-test prep template
+
+Every `*.e2e-spec.ts` follows this skeleton:
+
+```ts
+describe('Mxx — <area>', () => {
+  let standalone: StandaloneInstance;
+  let apiKey: string;
+  const credentialStoreService = `revisium-cli-e2e-${randomId()}`;
+
+  beforeAll(async () => {
+    standalone = await startStandalone({ auth: true, adminPassword: 'test-admin' });
+    const adminToken = await standalone.api.login();
+    apiKey = await standalone.api.mintApiKey('admin', { name: 'matrix' });
+    await standalone.api.seedFixture(/* per-suite seed */);
+  }, 120_000);
+
+  afterAll(async () => {
+    await standalone.stop();
+  });
+
+  it('<case>', async () => {
+    const workspace = createWorkspace();              // tempdir
+    writeWorkspaceConfig(workspace, { /* ... */ });    // optional
+    const env = {
+      ...CLEAR_REVISIUM_ENV,
+      REVISIUM_API_KEY: apiKey,
+      REVISIUM_CREDENTIAL_STORE_SERVICE: credentialStoreService,
+    };
+
+    const result = await runCli(['project', 'ensure', '--url', standalone.url(/* ... */)], { cwd: workspace, env });
+    expect(result.exitCode).toBe(0);
+    /* assertions on stdout/stderr + REST verification */
+  });
+});
+```
+
+## Running
+
+The matrix is opt-in. Default `npm run test:e2e` keeps existing CI fast.
+
+- `npm run test:e2e:matrix` — run only `e2e/matrix/*.e2e-spec.ts` (suite per file, fresh standalone per file).
+- `npm run test:e2e:matrix -- --testPathPattern=M06` — run a single suite.
+- `npm run test:e2e:matrix:ci` — used by the alpha pipeline; pins `@revisium/standalone` to a known stable version.
+
+## Pinning
+
+`package.json` keeps `@revisium/standalone` as a dev dependency at the **last stable** version. The alpha CI install step explicitly resolves that version so the matrix never runs against a moving target.

--- a/e2e/matrix/README.md
+++ b/e2e/matrix/README.md
@@ -290,7 +290,7 @@ Each row below is implemented as one `*.e2e-spec.ts` file in `e2e/matrix/`. The 
 
 ## Helper layout
 
-```
+```text
 e2e/utils/
   standalone-runner.ts   — spawns @revisium/standalone, waits for /health/readiness, returns { baseUrl, port, api, url(), stop() }
   standalone-api.ts      — REST/GraphQL helpers: login, mintApiKey, createProject, projectExists, seedTable, seedRow, listTables, listEndpoints

--- a/e2e/matrix/README.md
+++ b/e2e/matrix/README.md
@@ -34,7 +34,7 @@ Each suite spins up a **fresh standalone** in a temp data directory, prepares it
 | --------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | **AUTH-NONE**         | _no `--auth`_        | start standalone; CLI talks to it without credentials                                                              |
 | **AUTH-TOKEN**        | `--auth`             | log in as admin (`ADMIN_PASSWORD`); use returned JWT as `--token`/`REVISIUM_TOKEN`                                 |
-| **AUTH-APIKEY**       | `--auth`             | login → mint org-scoped API key via `POST /api/api-keys`; use as `--api-key`/`REVISIUM_API_KEY`                    |
+| **AUTH-APIKEY**       | `--auth`             | login → mint org-scoped API key via `POST /api/organizations/<org>/api-keys`; use as `--api-key`/`REVISIUM_API_KEY` |
 | **AUTH-PASSWORD**     | `--auth`             | use `REVISIUM_USERNAME` / `REVISIUM_PASSWORD` env (or `user:pass@host` URL form)                                   |
 | **AUTH-STORED**       | `--auth`             | `revisium auth login --api-key-stdin` saves to OS keyring under per-test service name; subsequent commands resolve |
 | **AUTH-URL-TOKEN**    | `--auth`             | embed `?token=...` in URL                                                                                          |
@@ -292,8 +292,8 @@ Each row below is implemented as one `*.e2e-spec.ts` file in `e2e/matrix/`. The 
 
 ```
 e2e/utils/
-  standalone-runner.ts   — spawns @revisium/standalone, waits for /health/readiness, returns { baseUrl, adminToken, stop() }
-  standalone-api.ts      — REST/GraphQL helpers: login, mintApiKey, createProject, seedTable, seedRows, getEndpoints, getRows
+  standalone-runner.ts   — spawns @revisium/standalone, waits for /health/readiness, returns { baseUrl, port, api, url(), stop() }
+  standalone-api.ts      — REST/GraphQL helpers: login, mintApiKey, createProject, projectExists, seedTable, seedRow, listTables, listEndpoints
   matrix-fixtures.ts     — pure fixture builders (tagSchema, faqSchema, questsRows, bootstrapConfig)
   matrix-workspace.ts    — tempdir + workspace-config helpers (writeConfig, withCredentialStoreNamespace)
 e2e/matrix/
@@ -347,7 +347,7 @@ The matrix is opt-in. Default `npm run test:e2e` keeps existing CI fast.
 
 - `npm run test:e2e:matrix` — run only `e2e/matrix/*.e2e-spec.ts` (suite per file, fresh standalone per file).
 - `npm run test:e2e:matrix -- --testPathPattern=M06` — run a single suite.
-- `npm run test:e2e:matrix:ci` — used by the alpha pipeline; pins `@revisium/standalone` to a known stable version.
+- `npm run test:e2e:matrix:cov` — instrumented build for coverage reporting; same suite set.
 
 ## Pinning
 

--- a/e2e/utils/cli-runner.ts
+++ b/e2e/utils/cli-runner.ts
@@ -12,13 +12,15 @@ export interface CliOptions {
   env?: Record<string, string>;
   timeout?: number;
   cwd?: string;
+  /** Optional stdin payload written to the CLI process before EOF. */
+  stdin?: string;
 }
 
 export async function runCli(
   args: string[],
   options: CliOptions = {},
 ): Promise<CliResult> {
-  const { env = {}, timeout = 60000, cwd = process.cwd() } = options;
+  const { env = {}, timeout = 60000, cwd = process.cwd(), stdin } = options;
 
   const isInstrumented = process.env.E2E_INSTRUMENTED === '1';
   const projectRoot = process.cwd();
@@ -43,6 +45,13 @@ export async function runCli(
       },
       stdio: ['pipe', 'pipe', 'pipe'],
     });
+
+    if (stdin !== undefined) {
+      child.stdin?.write(stdin);
+      child.stdin?.end();
+    } else {
+      child.stdin?.end();
+    }
 
     let stdout = '';
     let stderr = '';

--- a/e2e/utils/matrix-fixtures.ts
+++ b/e2e/utils/matrix-fixtures.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure fixture builders for the matrix. Each function returns deep copies so
+ * tests can mutate freely without leaking state between cases.
+ */
+
+export interface BootstrapTableConfig {
+  id: string;
+  schema: object;
+}
+
+export interface BootstrapRowConfig {
+  tableId: string;
+  rowId: string;
+  data: object;
+}
+
+export interface BootstrapConfigShape {
+  projectName?: string;
+  branchName?: string;
+  endpoints?: Array<'REST_API' | 'GRAPHQL'>;
+  tables?: BootstrapTableConfig[];
+  rows?: BootstrapRowConfig[];
+  commitMessage?: string;
+}
+
+// --- table schemas ----------------------------------------------------------
+
+export function tagSchema(): object {
+  return clone({
+    type: 'object',
+    required: ['label'],
+    additionalProperties: false,
+    properties: {
+      label: { type: 'string', default: '' },
+      slug: { type: 'string', default: '' },
+    },
+  });
+}
+
+export function faqSchema(): object {
+  return clone({
+    type: 'object',
+    required: ['name'],
+    additionalProperties: false,
+    properties: {
+      name: { type: 'string', default: '' },
+      summary: { type: 'string', default: '' },
+    },
+  });
+}
+
+export function questSchema(): object {
+  return clone({
+    type: 'object',
+    required: ['title'],
+    additionalProperties: false,
+    properties: {
+      title: { type: 'string', default: '' },
+      points: { type: 'integer', default: 0 },
+      published: { type: 'boolean', default: false },
+    },
+  });
+}
+
+// --- row builders -----------------------------------------------------------
+
+export function tagRows(count: number = 3): BootstrapRowConfig[] {
+  return Array.from({ length: count }, (_, i) => ({
+    tableId: 'Tag',
+    rowId: `tag-${i + 1}`,
+    data: { label: `Tag ${i + 1}`, slug: `tag-${i + 1}` },
+  }));
+}
+
+export function faqRows(): BootstrapRowConfig[] {
+  return [
+    {
+      tableId: 'FaqCategory',
+      rowId: 'billing',
+      data: { name: 'Billing', summary: 'Payments and invoices' },
+    },
+    {
+      tableId: 'FaqCategory',
+      rowId: 'general',
+      data: { name: 'General', summary: 'Anything else' },
+    },
+  ];
+}
+
+export function questRows(count: number = 50): BootstrapRowConfig[] {
+  return Array.from({ length: count }, (_, i) => ({
+    tableId: 'Quest',
+    rowId: `quest-${String(i + 1).padStart(3, '0')}`,
+    data: {
+      title: `Quest ${i + 1}`,
+      points: (i + 1) * 10,
+      published: i % 2 === 0,
+    },
+  }));
+}
+
+// --- bootstrap configs ------------------------------------------------------
+
+export function bootstrapConfig(
+  partial: BootstrapConfigShape = {},
+): BootstrapConfigShape {
+  return clone({
+    endpoints: ['REST_API', 'GRAPHQL'],
+    tables: [],
+    rows: [],
+    ...partial,
+  });
+}
+
+export function tagBootstrapConfig(projectName: string): BootstrapConfigShape {
+  return bootstrapConfig({
+    projectName,
+    branchName: 'master',
+    endpoints: ['REST_API'],
+    tables: [{ id: 'Tag', schema: tagSchema() }],
+    rows: tagRows(3),
+    commitMessage: 'Bootstrap tag fixture',
+  });
+}
+
+export function faqBootstrapConfig(projectName: string): BootstrapConfigShape {
+  return bootstrapConfig({
+    projectName,
+    branchName: 'master',
+    endpoints: ['REST_API', 'GRAPHQL'],
+    tables: [{ id: 'FaqCategory', schema: faqSchema() }],
+    rows: faqRows(),
+    commitMessage: 'Bootstrap faq fixture',
+  });
+}
+
+// --- helpers ----------------------------------------------------------------
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/e2e/utils/matrix-workspace.ts
+++ b/e2e/utils/matrix-workspace.ts
@@ -1,0 +1,105 @@
+import { randomBytes } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/** Set every `REVISIUM_*` env var the CLI consults to empty so tests start
+ *  from a clean slate, then layer in only what each case needs. */
+export const CLEAR_REVISIUM_ENV: Record<string, string> = {
+  REVISIUM_URL: '',
+  REVISIUM_TOKEN: '',
+  REVISIUM_API_KEY: '',
+  REVISIUM_USERNAME: '',
+  REVISIUM_PASSWORD: '',
+  REVISIUM_HOST: '',
+  REVISIUM_ORG: '',
+  REVISIUM_PROJECT: '',
+  REVISIUM_BRANCH: '',
+  REVISIUM_REVISION: '',
+  REVISIUM_SOURCE_URL: '',
+  REVISIUM_SOURCE_TOKEN: '',
+  REVISIUM_SOURCE_API_KEY: '',
+  REVISIUM_SOURCE_USERNAME: '',
+  REVISIUM_SOURCE_PASSWORD: '',
+  REVISIUM_TARGET_URL: '',
+  REVISIUM_TARGET_TOKEN: '',
+  REVISIUM_TARGET_API_KEY: '',
+  REVISIUM_TARGET_USERNAME: '',
+  REVISIUM_TARGET_PASSWORD: '',
+};
+
+export interface WorkspaceInstanceConfig {
+  baseUrl: string;
+  authMode?: 'none' | 'stored';
+}
+
+export interface WorkspaceContextConfig {
+  instance: string;
+  organization?: string;
+  project?: string;
+  branch?: string;
+  revision?: string;
+  credential?: string;
+}
+
+export interface WorkspaceConfigShape {
+  version?: number;
+  currentContext?: string;
+  instances?: Record<string, WorkspaceInstanceConfig>;
+  contexts?: Record<string, WorkspaceContextConfig>;
+}
+
+/** Create a brand-new workspace tempdir and return its absolute path. */
+export function createWorkspace(
+  prefix: string = 'revisium-cli-matrix-',
+): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** Write `<workspace>/.revisium/revisium-cli.config.json`. */
+export function writeWorkspaceConfig(
+  workspace: string,
+  config: WorkspaceConfigShape,
+): string {
+  const dir = path.join(workspace, '.revisium');
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, 'revisium-cli.config.json');
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({ version: 1, ...config }, null, 2),
+    'utf-8',
+  );
+  return filePath;
+}
+
+/** Returns the absolute path to an arbitrary file in the workspace. */
+export function workspaceFile(
+  workspace: string,
+  ...segments: string[]
+): string {
+  return path.join(workspace, ...segments);
+}
+
+/** Generates a unique credential-store namespace so saved API keys don't
+ *  collide between parallel tests or with the developer's real keyring. */
+export function uniqueCredentialStoreService(
+  prefix: string = 'revisium-cli-e2e',
+): string {
+  return `${prefix}-${randomBytes(6).toString('hex')}`;
+}
+
+/** Best-effort cleanup. Tests should still run inside an `afterAll` that
+ *  collects workspaces so a thrown assertion doesn't strand temp dirs. */
+export function removeWorkspace(workspace: string): void {
+  fs.rmSync(workspace, { recursive: true, force: true });
+}
+
+export function writeBootstrapConfigFile(
+  workspace: string,
+  data: unknown,
+  filename: string = 'bootstrap.config.json',
+): string {
+  const filePath = workspaceFile(workspace, filename);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
+  return filePath;
+}

--- a/e2e/utils/matrix-workspace.ts
+++ b/e2e/utils/matrix-workspace.ts
@@ -26,6 +26,7 @@ export const CLEAR_REVISIUM_ENV: Record<string, string> = {
   REVISIUM_TARGET_API_KEY: '',
   REVISIUM_TARGET_USERNAME: '',
   REVISIUM_TARGET_PASSWORD: '',
+  REVISIUM_ENV_FILE: '',
 };
 
 export interface WorkspaceInstanceConfig {

--- a/e2e/utils/standalone-api.ts
+++ b/e2e/utils/standalone-api.ts
@@ -120,8 +120,11 @@ export class StandaloneApiClient {
         { data: { organizationId: organization, projectName } },
       );
       return true;
-    } catch {
-      return false;
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return false;
+      }
+      throw error;
     }
   }
 
@@ -204,6 +207,28 @@ export class StandaloneApiClient {
     return data.tables.edges.map((edge) => edge.node);
   }
 
+  async listRows(
+    organization: string,
+    projectName: string,
+    tableId: string,
+    branchName: string = 'master',
+  ): Promise<Array<{ id: string; data: unknown }>> {
+    const revisionId = await this.getDraftRevisionId(
+      organization,
+      projectName,
+      branchName,
+    );
+    const data = await this.graphql<{
+      rows: { edges: Array<{ node: { id: string; data: unknown } }> };
+    }>(
+      `query($data: GetRowsInput!) {
+        rows(data: $data) { edges { node { id data } } }
+      }`,
+      { data: { revisionId, tableId, first: 1000 } },
+    );
+    return data.rows.edges.map((edge) => edge.node);
+  }
+
   async listEndpoints(
     organization: string,
     projectName: string,
@@ -279,4 +304,11 @@ export class StandaloneApiClient {
     }
     return result.data as T;
   }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return /not.?found|404/i.test(error.message);
 }

--- a/e2e/utils/standalone-api.ts
+++ b/e2e/utils/standalone-api.ts
@@ -1,0 +1,282 @@
+/**
+ * REST/GraphQL helpers used by the matrix to seed and inspect a fresh
+ * `@revisium/standalone` instance. This is intentionally separate from
+ * `e2e/utils/api-client.ts` (which targets the docker-compose admin instance
+ * and singletons a single token) so per-suite standalone fixtures stay
+ * isolated.
+ */
+
+export interface MintApiKeyOptions {
+  /** Human-readable name shown in the UI. */
+  name: string;
+  /** ISO timestamp; omit for non-expiring keys. */
+  expiresAt?: string;
+  /** Org-level role (e.g. `admin`, `developer`). */
+  role?: string;
+}
+
+export interface ApiKeyRecord {
+  id: string;
+  apiKey: string;
+  name: string;
+}
+
+export interface SeedTableInput {
+  organization: string;
+  project: string;
+  branch?: string;
+  tableId: string;
+  schema: object;
+}
+
+export interface SeedRowInput {
+  organization: string;
+  project: string;
+  branch?: string;
+  tableId: string;
+  rowId: string;
+  data: object;
+}
+
+export class StandaloneApiClient {
+  private token: string | undefined;
+
+  constructor(public readonly baseUrl: string) {}
+
+  // --- auth -----------------------------------------------------------------
+
+  async login(
+    username: string = 'admin',
+    password: string = 'test-admin',
+  ): Promise<string> {
+    const data = await this.request<{ accessToken: string }>(
+      'POST',
+      '/api/auth/login',
+      { emailOrUsername: username, password },
+    );
+    this.token = data.accessToken;
+    return this.token;
+  }
+
+  setToken(token: string): void {
+    this.token = token;
+  }
+
+  clearToken(): void {
+    this.token = undefined;
+  }
+
+  /**
+   * Mints a server API key scoped to the given organization. The exact
+   * REST shape is taken from the standalone OpenAPI; tests should not depend
+   * on internal field names beyond `apiKey`.
+   */
+  async mintApiKey(
+    organization: string,
+    options: MintApiKeyOptions,
+  ): Promise<ApiKeyRecord> {
+    const body: Record<string, unknown> = {
+      name: options.name,
+    };
+    if (options.expiresAt) body.expiresAt = options.expiresAt;
+    if (options.role) body.role = options.role;
+    return this.request<ApiKeyRecord>(
+      'POST',
+      `/api/organizations/${encodeURIComponent(organization)}/api-keys`,
+      body,
+    );
+  }
+
+  // --- projects -------------------------------------------------------------
+
+  async createProject(
+    organization: string,
+    projectName: string,
+    branchName: string = 'master',
+  ): Promise<void> {
+    await this.graphql(
+      `mutation($data: CreateProjectInput!) { createProject(data: $data) { id } }`,
+      { data: { organizationId: organization, projectName, branchName } },
+    );
+  }
+
+  async deleteProject(
+    organization: string,
+    projectName: string,
+  ): Promise<void> {
+    await this.graphql(
+      `mutation($data: DeleteProjectInput!) { deleteProject(data: $data) }`,
+      { data: { organizationId: organization, projectName } },
+    );
+  }
+
+  async projectExists(
+    organization: string,
+    projectName: string,
+  ): Promise<boolean> {
+    try {
+      await this.graphql(
+        `query($data: GetProjectInput!) { project(data: $data) { id } }`,
+        { data: { organizationId: organization, projectName } },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // --- branches / revisions -------------------------------------------------
+
+  async getDraftRevisionId(
+    organization: string,
+    projectName: string,
+    branchName: string = 'master',
+  ): Promise<string> {
+    const data = await this.graphql<{
+      project: { branch: { draft: { id: string } } };
+    }>(
+      `query($data: GetProjectInput!, $branch: String!) {
+        project(data: $data) {
+          branch(name: $branch) { draft { id } }
+        }
+      }`,
+      {
+        data: { organizationId: organization, projectName },
+        branch: branchName,
+      },
+    );
+    return data.project.branch.draft.id;
+  }
+
+  // --- tables / rows --------------------------------------------------------
+
+  async seedTable(input: SeedTableInput): Promise<void> {
+    const revisionId = await this.getDraftRevisionId(
+      input.organization,
+      input.project,
+      input.branch,
+    );
+    await this.graphql(
+      `mutation($data: CreateTableInput!) { createTable(data: $data) { id } }`,
+      {
+        data: { revisionId, tableId: input.tableId, schema: input.schema },
+      },
+    );
+  }
+
+  async seedRow(input: SeedRowInput): Promise<void> {
+    const revisionId = await this.getDraftRevisionId(
+      input.organization,
+      input.project,
+      input.branch,
+    );
+    await this.graphql(
+      `mutation($data: CreateRowInput!) { createRow(data: $data) { id } }`,
+      {
+        data: {
+          revisionId,
+          tableId: input.tableId,
+          rowId: input.rowId,
+          data: input.data,
+        },
+      },
+    );
+  }
+
+  async listTables(
+    organization: string,
+    projectName: string,
+    branchName: string = 'master',
+  ): Promise<Array<{ id: string }>> {
+    const revisionId = await this.getDraftRevisionId(
+      organization,
+      projectName,
+      branchName,
+    );
+    const data = await this.graphql<{
+      tables: { edges: Array<{ node: { id: string } }> };
+    }>(
+      `query($data: GetTablesInput!) {
+        tables(data: $data) { edges { node { id } } }
+      }`,
+      { data: { revisionId, first: 100 } },
+    );
+    return data.tables.edges.map((edge) => edge.node);
+  }
+
+  async listEndpoints(
+    organization: string,
+    projectName: string,
+    branchName: string = 'master',
+  ): Promise<Array<{ id: string; type: string }>> {
+    const revisionId = await this.getDraftRevisionId(
+      organization,
+      projectName,
+      branchName,
+    );
+    const data = await this.graphql<{
+      endpoints: Array<{ id: string; type: string }>;
+    }>(
+      `query($revisionId: String!) {
+        endpoints(revisionId: $revisionId) { id type }
+      }`,
+      { revisionId },
+    );
+    return data.endpoints;
+  }
+
+  // --- transports -----------------------------------------------------------
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `${method} ${path} failed: ${response.status} ${response.statusText} ${text}`,
+      );
+    }
+    return (await response.json()) as T;
+  }
+
+  private async graphql<T>(query: string, variables?: unknown): Promise<T> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+    const response = await fetch(`${this.baseUrl}/graphql`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query, variables }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `graphql failed: ${response.status} ${response.statusText} ${text}`,
+      );
+    }
+    const result = (await response.json()) as {
+      data?: T;
+      errors?: Array<{ message: string }>;
+    };
+    if (result.errors?.length) {
+      throw new Error(`graphql error: ${result.errors[0].message}`);
+    }
+    return result.data as T;
+  }
+}

--- a/e2e/utils/standalone-runner.ts
+++ b/e2e/utils/standalone-runner.ts
@@ -63,7 +63,7 @@ export async function startStandalone(
   } = options;
 
   if (auth && !adminPassword) {
-    throw new Error(
+    throw new TypeError(
       'startStandalone: adminPassword is required when auth=true',
     );
   }

--- a/e2e/utils/standalone-runner.ts
+++ b/e2e/utils/standalone-runner.ts
@@ -151,15 +151,23 @@ function buildRevisiumUrl(
 async function waitForReady(url: string, timeoutMs: number): Promise<void> {
   const start = Date.now();
   let lastError: unknown;
+  const perRequestTimeoutMs = 5_000;
   while (Date.now() - start < timeoutMs) {
+    const controller = new AbortController();
+    const abortTimer = setTimeout(
+      () => controller.abort(),
+      perRequestTimeoutMs,
+    );
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: controller.signal });
       if (response.ok) {
         return;
       }
       lastError = new Error(`HTTP ${response.status}`);
     } catch (error) {
       lastError = error;
+    } finally {
+      clearTimeout(abortTimer);
     }
     await sleep(500);
   }
@@ -174,9 +182,14 @@ async function stopProcess(
 ): Promise<void> {
   if (!child.killed && child.exitCode === null) {
     child.kill('SIGTERM');
-    await waitForExit(child, 5_000).catch(() => {
+    try {
+      await waitForExit(child, 5_000);
+    } catch {
       child.kill('SIGKILL');
-    });
+      // Wait for the kernel to actually reap the process before deleting its
+      // data dir; otherwise embedded PostgreSQL may still be holding files.
+      await waitForExit(child, 5_000).catch(() => undefined);
+    }
   }
   await rm(dataDir, { recursive: true, force: true });
 }

--- a/e2e/utils/standalone-runner.ts
+++ b/e2e/utils/standalone-runner.ts
@@ -1,0 +1,263 @@
+import { ChildProcess, spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { StandaloneApiClient } from './standalone-api';
+
+export interface StartStandaloneOptions {
+  /** Enable Revisium auth (default: false). */
+  auth?: boolean;
+  /**
+   * Initial admin password. Required when auth=true; ignored otherwise.
+   * Passed via `ADMIN_PASSWORD` env on first run.
+   */
+  adminPassword?: string;
+  /**
+   * Override the standalone version pulled by `npx`. Defaults to whatever the
+   * pinned dev dependency resolves to via `npm exec @revisium/standalone`.
+   */
+  version?: string;
+  /**
+   * Optional environment overrides forwarded to the standalone process.
+   */
+  env?: Record<string, string>;
+  /** Maximum time to wait for `/health/readiness` (ms, default 120s). */
+  readinessTimeoutMs?: number;
+}
+
+export interface StandaloneInstance {
+  /** HTTP base URL, no trailing slash, e.g. `http://localhost:9230`. */
+  baseUrl: string;
+  /** Bound HTTP port. */
+  port: number;
+  /** Embedded PostgreSQL port. */
+  pgPort: number;
+  /** Whether the instance was started with `--auth`. */
+  auth: boolean;
+  /** Pre-bound REST/GraphQL helper for seeding. */
+  api: StandaloneApiClient;
+  /**
+   * Returns a `revisium://host:port` base URL (used by CLI tests as `--url`).
+   * Adds `/org/project/branch[:revision]` segments when arguments are given.
+   */
+  url: (parts?: {
+    organization?: string;
+    project?: string;
+    branch?: string;
+    revision?: string;
+  }) => string;
+  /** Shut the process down and remove its data directory. */
+  stop: () => Promise<void>;
+}
+
+export async function startStandalone(
+  options: StartStandaloneOptions = {},
+): Promise<StandaloneInstance> {
+  const {
+    auth = false,
+    adminPassword,
+    version,
+    env: extraEnv = {},
+    readinessTimeoutMs = 120_000,
+  } = options;
+
+  if (auth && !adminPassword) {
+    throw new Error(
+      'startStandalone: adminPassword is required when auth=true',
+    );
+  }
+
+  const dataDir = await mkdtemp(join(tmpdir(), 'revisium-standalone-'));
+  const port = await pickFreePort(9222);
+  const pgPort = await pickFreePort(5440);
+
+  const args = [
+    '--yes',
+    version ? `@revisium/standalone@${version}` : '@revisium/standalone',
+    '--port',
+    String(port),
+    '--pg-port',
+    String(pgPort),
+    '--data',
+    dataDir,
+  ];
+  if (auth) {
+    args.push('--auth');
+  }
+
+  const child = spawn('npx', args, {
+    env: {
+      ...process.env,
+      ...(adminPassword ? { ADMIN_PASSWORD: adminPassword } : {}),
+      ...extraEnv,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  attachLogPipes(child, port);
+
+  const baseUrl = `http://localhost:${port}`;
+  const api = new StandaloneApiClient(baseUrl);
+
+  try {
+    await waitForReady(`${baseUrl}/health/readiness`, readinessTimeoutMs);
+  } catch (error) {
+    await stopProcess(child, dataDir);
+    throw error;
+  }
+
+  let stopped = false;
+  return {
+    baseUrl,
+    port,
+    pgPort,
+    auth,
+    api,
+    url: (parts) => buildRevisiumUrl(port, parts),
+    stop: async () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      await stopProcess(child, dataDir);
+    },
+  };
+}
+
+/**
+ * Build a `revisium://localhost:<port>[/org/project/branch[:rev]]` URL for the
+ * matrix tests. Defaults match the standalone defaults (`admin` org).
+ */
+function buildRevisiumUrl(
+  port: number,
+  parts: {
+    organization?: string;
+    project?: string;
+    branch?: string;
+    revision?: string;
+  } = {},
+): string {
+  const host = `localhost:${port}`;
+  if (!parts.project) {
+    return `revisium://${host}`;
+  }
+  const org = parts.organization ?? 'admin';
+  const branch = parts.branch ?? 'master';
+  const tail = parts.revision ? `:${parts.revision}` : '';
+  return `revisium://${host}/${org}/${parts.project}/${branch}${tail}`;
+}
+
+async function waitForReady(url: string, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  let lastError: unknown;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(500);
+  }
+  throw new Error(
+    `Standalone readiness check timed out at ${url}: ${formatError(lastError)}`,
+  );
+}
+
+async function stopProcess(
+  child: ChildProcess,
+  dataDir: string,
+): Promise<void> {
+  if (!child.killed && child.exitCode === null) {
+    child.kill('SIGTERM');
+    await waitForExit(child, 5_000).catch(() => {
+      child.kill('SIGKILL');
+    });
+  }
+  await rm(dataDir, { recursive: true, force: true });
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('standalone exit timeout')),
+      timeoutMs,
+    );
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+function attachLogPipes(child: ChildProcess, port: number): void {
+  if (process.env.E2E_STANDALONE_LOGS === '1') {
+    const tag = `[standalone:${port}]`;
+    child.stdout?.on('data', (chunk: Buffer) => {
+      process.stderr.write(`${tag} ${chunk.toString()}`);
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      process.stderr.write(`${tag} ${chunk.toString()}`);
+    });
+  } else {
+    // Drain so the process never blocks on a full pipe buffer.
+    child.stdout?.resume();
+    child.stderr?.resume();
+  }
+}
+
+async function pickFreePort(preferred: number): Promise<number> {
+  // Best-effort: try preferred first, fall back to a random offset. Standalone
+  // handles port collisions internally with `--port`, but reusing a port
+  // across two parallel suites in the same Jest run causes flakes.
+  const candidates = [preferred, ...randomOffsets(preferred, 16)];
+  for (const candidate of candidates) {
+    if (await isPortFree(candidate)) {
+      return candidate;
+    }
+  }
+  return preferred;
+}
+
+function randomOffsets(base: number, count: number): number[] {
+  const offsets = new Set<number>();
+  while (offsets.size < count) {
+    offsets.add(base + (randomBytes(2).readUInt16LE() % 2_000));
+  }
+  return Array.from(offsets);
+}
+
+async function isPortFree(port: number): Promise<boolean> {
+  const net = await import('node:net');
+  return await new Promise<boolean>((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => server.close(() => resolve(true)));
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (error === undefined || error === null) {
+    return 'unknown error';
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return 'unknown error';
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "test:e2e:cov": "npm run build:instrumented && E2E_INSTRUMENTED=1 jest --config ./e2e/jest-e2e.json",
     "test:e2e:up": "FILE_PLUGIN_PUBLIC_ENDPOINT=https://cdn.example.com npx @revisium/standalone --auth --port 8082 --data .e2e-test & echo $! > .e2e-test.pid",
     "test:e2e:down": "if [ -f .e2e-test.pid ]; then kill $(cat .e2e-test.pid) 2>/dev/null; rm -f .e2e-test.pid; fi; rm -rf .e2e-test",
+    "test:e2e:matrix": "npm run build && jest --config ./e2e/jest-matrix.json",
+    "test:e2e:matrix:cov": "npm run build:instrumented && E2E_INSTRUMENTED=1 jest --config ./e2e/jest-matrix.json",
     "build:instrumented": "npm run build && rm -rf dist-instrumented && mkdir -p dist-instrumented && cp dist/package.json dist-instrumented/ && npx nyc instrument dist/src dist-instrumented/src --include='**/*.js'",
     "test:all": "npm run test:cov && npm run test:e2e:cov && npm run coverage:merge",
     "coverage:merge": "node scripts/merge-coverage.js"


### PR DESCRIPTION
## Summary

Authors a comprehensive e2e matrix that exercises every `revisium-cli` command against a fresh `@revisium/standalone` instance per suite. Tests are **opt-in** (`npm run test:e2e:matrix`); they do not run on the default CI path. The intent is to wire them into a dedicated pipeline that pairs an **alpha CLI release** with a **stable standalone** version, so regressions are caught against a known-good fixture surface.

## What's in this PR

- `e2e/matrix/README.md` — full matrix design, axes (auth modes / target resolution / output flags), and per-suite prep-step documentation.
- `e2e/utils/standalone-runner.ts` — spawns `@revisium/standalone`, picks free ports, waits for `/health/readiness`, removes temp data dir on stop.
- `e2e/utils/standalone-api.ts` — REST/GraphQL helpers used to seed fixtures (`login`, `mintApiKey`, `createProject`, `seedTable`, `seedRow`, `listTables`, `listEndpoints`).
- `e2e/utils/matrix-fixtures.ts` — pure schema/row/bootstrap-config builders.
- `e2e/utils/matrix-workspace.ts` — workspace tempdir, env-clearing, credential-store namespacing, workspace-config writer.
- 14 spec files (`M01`..`M14`) covering: auth commands, instance/context CRUD, project/endpoint ensure, example bootstrap, migrate, schema, rows, sync, target/auth precedence, error paths, no-auth mode, multi-instance workspace.
- `e2e/jest-matrix.json` + `npm run test:e2e:matrix` / `test:e2e:matrix:cov` scripts.
- `runCli` extended with `stdin` for `--api-key-stdin` flows.

## What's *not* in this PR

- The matrix is **not** executed here — `npm run test:e2e:matrix` is opt-in and meant for the alpha pipeline.
- `--no-input` test cases are noted in the design but skipped pending the dedicated common-flags PR.

## Validation

- `npm run tsc` — green
- `npm run lint:ci` — green
- `npm test -- --runInBand` — unchanged (matrix tests live under `e2e/matrix/`, excluded from default jest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive "matrix" end-to-end test suite exercising CLI auth, instance/context management, project/endpoint/schema/rows workflows, migrations, sync, error paths, and multi-instance scenarios.
* **Documentation**
  * Added a matrix E2E README describing how to run and reproduce tests against local standalone instances.
* **Chores**
  * Added npm scripts to run the matrix E2E suite (regular and coverage).
* **Tests**
  * Test runner enhanced to support providing stdin to CLI invocations for automation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-cli/pull/79)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->