### PR TITLE
fix: address matrix-alpha CLI gaps

### DIFF
--- a/e2e/tests/07-workspace-config.e2e-spec.ts
+++ b/e2e/tests/07-workspace-config.e2e-spec.ts
@@ -338,7 +338,7 @@ describe('Workspace config commands', () => {
     });
 
     expect(saveResult.exitCode).toBe(0);
-    expect(saveResult.stdout).toContain(
+    expect(saveResult.stdout + saveResult.stderr).toContain(
       'Using context demo (instance: local-no-auth)',
     );
     expect(saveResult.stdout).toContain('Authenticated as no auth');
@@ -357,11 +357,24 @@ async function createStoredWorkspaceContext(
   contextName: string,
   projectName: string,
 ): Promise<void> {
+  // --force so re-adding "local" across multiple createStoredWorkspaceContext
+  // calls in the same test workspace is a no-op rather than an error
+  // (instance add now rejects duplicates without --force).
   await expectSuccess(
-    runCli(['instance', 'add', 'local', '--url', 'revisium://localhost:8082'], {
-      cwd: workspace,
-      env: CLEAR_REVISIUM_ENV,
-    }),
+    runCli(
+      [
+        'instance',
+        'add',
+        'local',
+        '--url',
+        'revisium://localhost:8082',
+        '--force',
+      ],
+      {
+        cwd: workspace,
+        env: CLEAR_REVISIUM_ENV,
+      },
+    ),
   );
   await expectSuccess(
     runCli(['context', 'create', contextName, '--url', buildUrl(projectName)], {

--- a/e2e/tests/07-workspace-config.e2e-spec.ts
+++ b/e2e/tests/07-workspace-config.e2e-spec.ts
@@ -224,7 +224,9 @@ describe('Workspace config commands', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('Using context current (instance: local)');
+    expect(result.stdout + result.stderr).toContain(
+      'Using context current (instance: local)',
+    );
     expect(result.stdout).toContain('Authenticated as admin');
     expect(fs.readdirSync(outputDir)).toHaveLength(14);
   });
@@ -257,7 +259,7 @@ describe('Workspace config commands', () => {
     );
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain(
+    expect(result.stdout + result.stderr).toContain(
       'Using context populated (instance: local)',
     );
     expect(result.stdout).toContain(`Project: admin/${populatedProject.name}`);
@@ -324,7 +326,7 @@ describe('Workspace config commands', () => {
     );
 
     expect(migrateResult.exitCode).toBe(0);
-    expect(migrateResult.stdout).toContain(
+    expect(migrateResult.stdout + migrateResult.stderr).toContain(
       'Using context demo (instance: local-no-auth)',
     );
     expect(migrateResult.stdout).toContain('Authenticated as no auth');

--- a/src/commands/context/__tests__/context-list.command.spec.ts
+++ b/src/commands/context/__tests__/context-list.command.spec.ts
@@ -1,0 +1,102 @@
+import { ContextListCommand } from '../context-list.command';
+import { LoggerService } from 'src/services/common';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+describe('ContextListCommand', () => {
+  let workspaceConfig: { load: jest.Mock };
+  let logger: { info: jest.Mock };
+  let command: ContextListCommand;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    workspaceConfig = { load: jest.fn() };
+    logger = { info: jest.fn() };
+    command = new ContextListCommand(
+      workspaceConfig as unknown as WorkspaceConfigService,
+      logger as unknown as LoggerService,
+    );
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('prints "no contexts configured" when workspace is empty', async () => {
+    workspaceConfig.load.mockResolvedValue(undefined);
+    await command.run([], {});
+    expect(logger.info).toHaveBeenCalledWith(
+      'No Revisium contexts configured in this workspace.',
+    );
+  });
+
+  it('lists contexts sorted by name with a current-context marker', async () => {
+    workspaceConfig.load.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: {
+        currentContext: 'beta',
+        contexts: {
+          beta: { instance: 'local', organization: 'admin', project: 'b' },
+          alpha: { instance: 'local', organization: 'admin', project: 'a' },
+        },
+      },
+    });
+    await command.run([], {});
+    const lines = logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(lines.find((l) => l.startsWith('  alpha\t'))).toBeDefined();
+    expect(lines.find((l) => l.startsWith('* beta\t'))).toBeDefined();
+  });
+
+  it('emits JSON with all parts and current flag', async () => {
+    workspaceConfig.load.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: {
+        currentContext: 'alpha',
+        contexts: {
+          alpha: {
+            instance: 'local',
+            organization: 'admin',
+            project: 'p',
+            branch: 'master',
+            revision: 'draft',
+            credential: 'default',
+          },
+        },
+      },
+    });
+    await command.run([], { json: true });
+    const firstCall = logSpy.mock.calls[0] as unknown[];
+    const payload = JSON.parse(firstCall[0] as string) as {
+      currentContext: string;
+      contexts: Array<{ name: string; current: boolean }>;
+    };
+    expect(payload.currentContext).toBe('alpha');
+    expect(payload.contexts).toEqual([
+      {
+        name: 'alpha',
+        instance: 'local',
+        organization: 'admin',
+        project: 'p',
+        branch: 'master',
+        revision: 'draft',
+        credential: 'default',
+        current: true,
+      },
+    ]);
+  });
+
+  it('emits JSON with empty list when workspace is unconfigured', async () => {
+    workspaceConfig.load.mockResolvedValue(undefined);
+    await command.run([], { json: true });
+    const firstCall = logSpy.mock.calls[0] as unknown[];
+    const payload = JSON.parse(firstCall[0] as string) as {
+      contexts: unknown[];
+    };
+    expect(payload.contexts).toEqual([]);
+  });
+
+  it('parseJson honours boolean values', () => {
+    expect(command.parseJson()).toBe(true);
+    expect(command.parseJson('false')).toBe(false);
+  });
+});

--- a/src/commands/context/context-list.command.ts
+++ b/src/commands/context/context-list.command.ts
@@ -1,10 +1,15 @@
-import { CommandRunner, SubCommand } from 'nest-commander';
+import { CommandRunner, Option, SubCommand } from 'nest-commander';
 import { LoggerService } from 'src/services/common';
 import {
   DEFAULT_BRANCH,
   DEFAULT_REVISION,
   WorkspaceConfigService,
 } from 'src/services/workspace';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+
+interface Options {
+  json?: boolean;
+}
 
 @SubCommand({
   name: 'list',
@@ -18,19 +23,54 @@ export class ContextListCommand extends CommandRunner {
     super();
   }
 
-  async run(): Promise<void> {
+  async run(_inputs: string[], options: Options = {}): Promise<void> {
     const loaded = await this.workspaceConfig.load();
-    if (!loaded || Object.keys(loaded.config.contexts).length === 0) {
+    const entries = loaded ? Object.entries(loaded.config.contexts) : [];
+    const sorted = [...entries].sort(([a], [b]) => a.localeCompare(b));
+
+    if (options.json) {
+      const contexts = sorted.map(([name, context]) => ({
+        name,
+        instance: context.instance,
+        organization: context.organization,
+        project: context.project,
+        branch: context.branch || DEFAULT_BRANCH,
+        revision: context.revision || DEFAULT_REVISION,
+        credential: context.credential,
+        current: loaded?.config.currentContext === name,
+      }));
+      console.log(
+        JSON.stringify(
+          {
+            currentContext: loaded?.config.currentContext,
+            contexts,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    if (sorted.length === 0) {
       this.logger.info('No Revisium contexts configured in this workspace.');
       return;
     }
 
-    this.logger.info(`Config: ${loaded.path}`);
-    for (const [name, context] of Object.entries(loaded.config.contexts)) {
-      const marker = loaded.config.currentContext === name ? '*' : ' ';
+    this.logger.info(`Config: ${loaded?.path}`);
+    for (const [name, context] of sorted) {
+      const marker = loaded?.config.currentContext === name ? '*' : ' ';
       this.logger.info(
         `${marker} ${name}\t${context.instance}\t${context.organization}/${context.project}/${context.branch || DEFAULT_BRANCH}:${context.revision || DEFAULT_REVISION}`,
       );
     }
+  }
+
+  @Option({
+    flags: '--json [boolean]',
+    description: 'Print machine-readable JSON',
+  })
+  parseJson(value?: string): boolean {
+    return parseBooleanOption(value);
   }
 }

--- a/src/commands/instance/__tests__/instance-add.command.spec.ts
+++ b/src/commands/instance/__tests__/instance-add.command.spec.ts
@@ -1,0 +1,93 @@
+import { InstanceAddCommand } from '../instance-add.command';
+import { LoggerService } from 'src/services/common';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+describe('InstanceAddCommand', () => {
+  let workspaceConfig: {
+    loadOrCreate: jest.Mock;
+    save: jest.Mock;
+    normalizeBaseUrl: jest.Mock;
+  };
+  let logger: { info: jest.Mock; success: jest.Mock };
+  let command: InstanceAddCommand;
+
+  beforeEach(() => {
+    workspaceConfig = {
+      loadOrCreate: jest.fn(),
+      save: jest.fn().mockResolvedValue(undefined),
+      normalizeBaseUrl: jest.fn((u: string) => u),
+    };
+    logger = { info: jest.fn(), success: jest.fn() };
+    command = new InstanceAddCommand(
+      workspaceConfig as unknown as WorkspaceConfigService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  function loadedWith(instances: Record<string, unknown> = {}): void {
+    workspaceConfig.loadOrCreate.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: { version: 1, instances, contexts: {} },
+    });
+  }
+
+  it('adds a new instance with default authMode "stored"', async () => {
+    loadedWith({});
+    await command.run(['local'], { url: 'revisium://localhost:9222' });
+    expect(workspaceConfig.save).toHaveBeenCalledWith(
+      '/repo/.revisium/revisium-cli.config.json',
+      expect.objectContaining({
+        instances: {
+          local: { baseUrl: 'revisium://localhost:9222', authMode: 'stored' },
+        },
+      }),
+    );
+    expect(logger.success).toHaveBeenCalledWith(
+      'Added instance "local" (revisium://localhost:9222, auth: stored)',
+    );
+  });
+
+  it('rejects re-adding an existing instance without --force', async () => {
+    loadedWith({ local: { baseUrl: 'http://existing', authMode: 'stored' } });
+    await expect(
+      command.run(['local'], { url: 'revisium://localhost:9222' }),
+    ).rejects.toThrow(/already exists.*--force/);
+    expect(workspaceConfig.save).not.toHaveBeenCalled();
+  });
+
+  it('overwrites with --force', async () => {
+    loadedWith({ local: { baseUrl: 'http://existing', authMode: 'stored' } });
+    await command.run(['local'], {
+      url: 'revisium://localhost:9230',
+      force: true,
+    });
+    expect(workspaceConfig.save).toHaveBeenCalled();
+    expect(logger.success).toHaveBeenCalledWith(
+      'Updated instance "local" (revisium://localhost:9230, auth: stored)',
+    );
+  });
+
+  it('rejects when name is missing', async () => {
+    await expect(
+      command.run([], { url: 'revisium://localhost:9222' }),
+    ).rejects.toThrow('instance name is required');
+  });
+
+  it('rejects when --url is missing', async () => {
+    await expect(command.run(['local'], {})).rejects.toThrow(
+      '--url option is required',
+    );
+  });
+
+  it('parseAuth accepts stored/none and rejects other values', () => {
+    expect(command.parseAuth('stored')).toBe('stored');
+    expect(command.parseAuth('none')).toBe('none');
+    expect(() => command.parseAuth('weird')).toThrow();
+  });
+
+  it('parseForce parses boolean option', () => {
+    expect(command.parseForce()).toBe(true);
+    expect(command.parseForce('true')).toBe(true);
+    expect(command.parseForce('false')).toBe(false);
+  });
+});

--- a/src/commands/instance/__tests__/instance-list.command.spec.ts
+++ b/src/commands/instance/__tests__/instance-list.command.spec.ts
@@ -1,0 +1,91 @@
+import { InstanceListCommand } from '../instance-list.command';
+import { LoggerService } from 'src/services/common';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+describe('InstanceListCommand', () => {
+  let workspaceConfig: { load: jest.Mock };
+  let logger: { info: jest.Mock };
+  let command: InstanceListCommand;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    workspaceConfig = { load: jest.fn() };
+    logger = { info: jest.fn() };
+    command = new InstanceListCommand(
+      workspaceConfig as unknown as WorkspaceConfigService,
+      logger as unknown as LoggerService,
+    );
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('prints "no instances configured" when workspace is empty', async () => {
+    workspaceConfig.load.mockResolvedValue(undefined);
+    await command.run([], {});
+    expect(logger.info).toHaveBeenCalledWith(
+      'No Revisium instances configured in this workspace.',
+    );
+  });
+
+  it('lists instances sorted by name', async () => {
+    workspaceConfig.load.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: {
+        instances: {
+          beta: { baseUrl: 'http://b', authMode: 'stored' },
+          alpha: { baseUrl: 'http://a', authMode: 'none' },
+        },
+      },
+    });
+    await command.run([], {});
+    const callTexts = logger.info.mock.calls.map(
+      (c: unknown[]) => c[0] as string,
+    );
+    const alphaIdx = callTexts.findIndex((t) => t.startsWith('alpha\t'));
+    const betaIdx = callTexts.findIndex((t) => t.startsWith('beta\t'));
+    expect(alphaIdx).toBeGreaterThanOrEqual(0);
+    expect(betaIdx).toBeGreaterThan(alphaIdx);
+  });
+
+  it('emits JSON with sorted instances when --json is set', async () => {
+    workspaceConfig.load.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: {
+        instances: {
+          beta: { baseUrl: 'http://b', authMode: 'stored' },
+          alpha: { baseUrl: 'http://a' },
+        },
+      },
+    });
+    await command.run([], { json: true });
+    const firstCall = logSpy.mock.calls[0] as unknown[];
+    const payload = JSON.parse(firstCall[0] as string) as {
+      instances: Array<{ name: string; baseUrl: string; authMode: string }>;
+    };
+    expect(payload).toEqual({
+      instances: [
+        { name: 'alpha', baseUrl: 'http://a', authMode: 'stored' },
+        { name: 'beta', baseUrl: 'http://b', authMode: 'stored' },
+      ],
+    });
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('emits JSON with empty list when workspace is unconfigured', async () => {
+    workspaceConfig.load.mockResolvedValue(undefined);
+    await command.run([], { json: true });
+    const firstCall = logSpy.mock.calls[0] as unknown[];
+    const payload = JSON.parse(firstCall[0] as string) as {
+      instances: unknown[];
+    };
+    expect(payload.instances).toEqual([]);
+  });
+
+  it('parseJson honours boolean values', () => {
+    expect(command.parseJson()).toBe(true);
+    expect(command.parseJson('false')).toBe(false);
+  });
+});

--- a/src/commands/instance/__tests__/instance-remove.command.spec.ts
+++ b/src/commands/instance/__tests__/instance-remove.command.spec.ts
@@ -1,0 +1,98 @@
+import { InstanceRemoveCommand } from '../instance-remove.command';
+import { LoggerService } from 'src/services/common';
+import { CredentialStoreService } from 'src/services/credentials';
+import { WorkspaceConfigService } from 'src/services/workspace';
+
+describe('InstanceRemoveCommand', () => {
+  let workspaceConfig: { load: jest.Mock; save: jest.Mock };
+  let credentialStore: { deleteCredential: jest.Mock };
+  let logger: { info: jest.Mock; success: jest.Mock };
+  let command: InstanceRemoveCommand;
+
+  beforeEach(() => {
+    workspaceConfig = {
+      load: jest.fn(),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    credentialStore = { deleteCredential: jest.fn() };
+    logger = { info: jest.fn(), success: jest.fn() };
+    command = new InstanceRemoveCommand(
+      workspaceConfig as unknown as WorkspaceConfigService,
+      credentialStore as unknown as CredentialStoreService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  function loaded(
+    instances: Record<string, { baseUrl: string }>,
+    contexts: Record<string, { instance: string }> = {},
+  ): void {
+    workspaceConfig.load.mockResolvedValue({
+      path: '/repo/.revisium/revisium-cli.config.json',
+      config: { version: 1, instances, contexts },
+    });
+  }
+
+  it('removes a known instance', async () => {
+    loaded({ local: { baseUrl: 'http://a' } });
+    await command.run(['local'], {});
+    expect(workspaceConfig.save).toHaveBeenCalledWith(
+      '/repo/.revisium/revisium-cli.config.json',
+      expect.objectContaining({ instances: {} }),
+    );
+    expect(credentialStore.deleteCredential).not.toHaveBeenCalled();
+    expect(logger.success).toHaveBeenCalledWith('Removed instance "local"');
+  });
+
+  it('rejects when name is missing', async () => {
+    await expect(command.run([], {})).rejects.toThrow(
+      'instance name is required',
+    );
+  });
+
+  it('rejects an unknown instance', async () => {
+    loaded({});
+    await expect(command.run(['ghost'], {})).rejects.toThrow(
+      'Revisium instance "ghost" was not found',
+    );
+  });
+
+  it('rejects when contexts still reference the instance', async () => {
+    loaded(
+      { local: { baseUrl: 'http://a' } },
+      { dictionary: { instance: 'local' } },
+    );
+    await expect(command.run(['local'], {})).rejects.toThrow(
+      /used by contexts: dictionary/,
+    );
+    expect(workspaceConfig.save).not.toHaveBeenCalled();
+  });
+
+  it('--with-credentials deletes the saved default credential', async () => {
+    loaded({ local: { baseUrl: 'http://a' } });
+    credentialStore.deleteCredential.mockReturnValue(true);
+    await command.run(['local'], { withCredentials: true });
+    expect(credentialStore.deleteCredential).toHaveBeenCalledWith({
+      baseUrl: 'http://a',
+      credential: 'default',
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      'Removed saved credential for "local"',
+    );
+  });
+
+  it('--with-credentials no-ops silently when there was no saved credential', async () => {
+    loaded({ local: { baseUrl: 'http://a' } });
+    credentialStore.deleteCredential.mockReturnValue(false);
+    await command.run(['local'], { withCredentials: true });
+    expect(credentialStore.deleteCredential).toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('Removed saved credential'),
+    );
+  });
+
+  it('parseWithCredentials parses boolean option', () => {
+    expect(command.parseWithCredentials()).toBe(true);
+    expect(command.parseWithCredentials('false')).toBe(false);
+  });
+});

--- a/src/commands/instance/__tests__/instance-remove.command.spec.ts
+++ b/src/commands/instance/__tests__/instance-remove.command.spec.ts
@@ -6,7 +6,7 @@ import { WorkspaceConfigService } from 'src/services/workspace';
 describe('InstanceRemoveCommand', () => {
   let workspaceConfig: { load: jest.Mock; save: jest.Mock };
   let credentialStore: { deleteCredential: jest.Mock };
-  let logger: { info: jest.Mock; success: jest.Mock };
+  let logger: { info: jest.Mock; success: jest.Mock; warn: jest.Mock };
   let command: InstanceRemoveCommand;
 
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('InstanceRemoveCommand', () => {
       save: jest.fn().mockResolvedValue(undefined),
     };
     credentialStore = { deleteCredential: jest.fn() };
-    logger = { info: jest.fn(), success: jest.fn() };
+    logger = { info: jest.fn(), success: jest.fn(), warn: jest.fn() };
     command = new InstanceRemoveCommand(
       workspaceConfig as unknown as WorkspaceConfigService,
       credentialStore as unknown as CredentialStoreService,
@@ -89,6 +89,21 @@ describe('InstanceRemoveCommand', () => {
     expect(logger.info).not.toHaveBeenCalledWith(
       expect.stringContaining('Removed saved credential'),
     );
+  });
+
+  it('--with-credentials warns but still succeeds when keyring throws', async () => {
+    loaded({ local: { baseUrl: 'http://a' } });
+    credentialStore.deleteCredential.mockImplementation(() => {
+      throw new Error('keyring offline');
+    });
+
+    await expect(
+      command.run(['local'], { withCredentials: true }),
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('saved credential could not be deleted'),
+    );
+    expect(logger.success).toHaveBeenCalledWith('Removed instance "local"');
   });
 
   it('parseWithCredentials parses boolean option', () => {

--- a/src/commands/instance/instance-add.command.ts
+++ b/src/commands/instance/instance-add.command.ts
@@ -4,16 +4,18 @@ import {
   WorkspaceAuthMode,
   WorkspaceConfigService,
 } from 'src/services/workspace';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
 
 interface Options {
   url?: string;
   auth?: WorkspaceAuthMode;
+  force?: boolean;
 }
 
 @SubCommand({
   name: 'add',
   arguments: '<name>',
-  description: 'Add or update a workspace Revisium instance',
+  description: 'Add a new workspace Revisium instance',
 })
 export class InstanceAddCommand extends CommandRunner {
   constructor(
@@ -36,6 +38,12 @@ export class InstanceAddCommand extends CommandRunner {
     const baseUrl = this.workspaceConfig.normalizeBaseUrl(options.url);
     const authMode = options.auth || 'stored';
     const existed = Boolean(loaded.config.instances[name]);
+
+    if (existed && !options.force) {
+      throw new Error(
+        `Revisium instance "${name}" already exists. Use --force to overwrite.`,
+      );
+    }
 
     loaded.config.instances[name] = {
       baseUrl,
@@ -68,5 +76,13 @@ export class InstanceAddCommand extends CommandRunner {
       throw new Error('Auth mode must be "stored" or "none"');
     }
     return value;
+  }
+
+  @Option({
+    flags: '--force [boolean]',
+    description: 'Overwrite an existing instance entry with the same name',
+  })
+  parseForce(value?: string): boolean {
+    return parseBooleanOption(value);
   }
 }

--- a/src/commands/instance/instance-list.command.ts
+++ b/src/commands/instance/instance-list.command.ts
@@ -1,6 +1,11 @@
-import { CommandRunner, SubCommand } from 'nest-commander';
+import { CommandRunner, Option, SubCommand } from 'nest-commander';
 import { LoggerService } from 'src/services/common';
 import { WorkspaceConfigService } from 'src/services/workspace';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+
+interface Options {
+  json?: boolean;
+}
 
 @SubCommand({
   name: 'list',
@@ -14,18 +19,39 @@ export class InstanceListCommand extends CommandRunner {
     super();
   }
 
-  async run(): Promise<void> {
+  async run(_inputs: string[], options: Options = {}): Promise<void> {
     const loaded = await this.workspaceConfig.load();
-    if (!loaded || Object.keys(loaded.config.instances).length === 0) {
+    const entries = loaded ? Object.entries(loaded.config.instances) : [];
+    const sorted = [...entries].sort(([a], [b]) => a.localeCompare(b));
+
+    if (options.json) {
+      const instances = sorted.map(([name, instance]) => ({
+        name,
+        baseUrl: instance.baseUrl,
+        authMode: instance.authMode || 'stored',
+      }));
+      console.log(JSON.stringify({ instances }, null, 2));
+      return;
+    }
+
+    if (sorted.length === 0) {
       this.logger.info('No Revisium instances configured in this workspace.');
       return;
     }
 
-    this.logger.info(`Config: ${loaded.path}`);
-    for (const [name, instance] of Object.entries(loaded.config.instances)) {
+    this.logger.info(`Config: ${loaded?.path}`);
+    for (const [name, instance] of sorted) {
       this.logger.info(
         `${name}\t${instance.baseUrl}\tauth:${instance.authMode || 'stored'}`,
       );
     }
+  }
+
+  @Option({
+    flags: '--json [boolean]',
+    description: 'Print machine-readable JSON',
+  })
+  parseJson(value?: string): boolean {
+    return parseBooleanOption(value);
   }
 }

--- a/src/commands/instance/instance-remove.command.ts
+++ b/src/commands/instance/instance-remove.command.ts
@@ -1,6 +1,12 @@
-import { CommandRunner, SubCommand } from 'nest-commander';
+import { CommandRunner, Option, SubCommand } from 'nest-commander';
 import { LoggerService } from 'src/services/common';
+import { CredentialStoreService } from 'src/services/credentials';
 import { WorkspaceConfigService } from 'src/services/workspace';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
+
+interface Options {
+  withCredentials?: boolean;
+}
 
 @SubCommand({
   name: 'remove',
@@ -10,12 +16,13 @@ import { WorkspaceConfigService } from 'src/services/workspace';
 export class InstanceRemoveCommand extends CommandRunner {
   constructor(
     private readonly workspaceConfig: WorkspaceConfigService,
+    private readonly credentialStore: CredentialStoreService,
     private readonly logger: LoggerService,
   ) {
     super();
   }
 
-  async run(inputs: string[]): Promise<void> {
+  async run(inputs: string[], options: Options = {}): Promise<void> {
     const name = inputs[0];
     if (!name) {
       throw new Error('Error: instance name is required');
@@ -36,9 +43,29 @@ export class InstanceRemoveCommand extends CommandRunner {
       );
     }
 
+    const baseUrl = loaded.config.instances[name].baseUrl;
     delete loaded.config.instances[name];
     await this.workspaceConfig.save(loaded.path, loaded.config);
 
+    if (options.withCredentials) {
+      const removed = this.credentialStore.deleteCredential({
+        baseUrl,
+        credential: 'default',
+      });
+      if (removed) {
+        this.logger.info(`Removed saved credential for "${name}"`);
+      }
+    }
+
     this.logger.success(`Removed instance "${name}"`);
+  }
+
+  @Option({
+    flags: '--with-credentials [boolean]',
+    description:
+      'Also delete the saved "default" API-key credential for this instance from the OS keyring',
+  })
+  parseWithCredentials(value?: string): boolean {
+    return parseBooleanOption(value);
   }
 }

--- a/src/commands/instance/instance-remove.command.ts
+++ b/src/commands/instance/instance-remove.command.ts
@@ -48,12 +48,21 @@ export class InstanceRemoveCommand extends CommandRunner {
     await this.workspaceConfig.save(loaded.path, loaded.config);
 
     if (options.withCredentials) {
-      const removed = this.credentialStore.deleteCredential({
-        baseUrl,
-        credential: 'default',
-      });
-      if (removed) {
-        this.logger.info(`Removed saved credential for "${name}"`);
+      // Best-effort: instance is already deleted from workspace config, so a
+      // keyring failure here shouldn't make the whole command fail.
+      try {
+        const removed = this.credentialStore.deleteCredential({
+          baseUrl,
+          credential: 'default',
+        });
+        if (removed) {
+          this.logger.info(`Removed saved credential for "${name}"`);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `Instance "${name}" was removed, but the saved credential could not be deleted: ${message}`,
+        );
       }
     }
 

--- a/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
+++ b/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
@@ -301,7 +301,21 @@ describe('BootstrapService', () => {
     });
   });
 
-  describe('ensureProject dry-run', () => {
+  describe('ensureProject', () => {
+    it('rejects non-draft target before any project is created', async () => {
+      connectionServiceFake.resolveTarget.mockResolvedValue({
+        ...target,
+        revision: 'head',
+      });
+
+      await expect(
+        service.ensureProject({ url: 'revisium://local' }),
+      ).rejects.toThrow('requires a draft revision');
+
+      expect(orgScopeFake.createProject).not.toHaveBeenCalled();
+      expect(projectScopeFake.createBranch).not.toHaveBeenCalled();
+    });
+
     it('does not call createProject in dry-run mode when missing', async () => {
       projectScopeFake.get.mockRejectedValue(new Error('Project not found'));
 

--- a/src/services/bootstrap/bootstrap.service.ts
+++ b/src/services/bootstrap/bootstrap.service.ts
@@ -101,6 +101,7 @@ export class BootstrapService {
     dryRun = false,
   ): Promise<ProjectEnsureResult> {
     const { url, apiClient } = await this.createResolvedClient(options);
+    this.assertWritableRevision(url);
     const branchName = url.branch || 'master';
     const orgScope = apiClient.client.org(url.organization);
     const projectScope = orgScope.project(url.project);

--- a/src/services/common/logger.service.ts
+++ b/src/services/common/logger.service.ts
@@ -6,6 +6,15 @@ export class LoggerService {
     console.log(message);
   }
 
+  /**
+   * Diagnostic lines (e.g. "Using context X", "Connecting to ...") that should
+   * not pollute stdout when the user has asked for `--json` machine-readable
+   * output. Routed to stderr so JSON consumers can parse stdout cleanly.
+   */
+  progress(message: string): void {
+    console.error(message);
+  }
+
   success(message: string): void {
     console.log(`✅ ${message}`);
   }

--- a/src/services/connection/__tests__/connection.service.spec.ts
+++ b/src/services/connection/__tests__/connection.service.spec.ts
@@ -20,7 +20,7 @@ describe('ConnectionService', () => {
     resolveConnection: jest.Mock;
   };
   let configServiceFake: { get: jest.Mock };
-  let loggerServiceFake: { info: jest.Mock };
+  let loggerServiceFake: { info: jest.Mock; progress: jest.Mock };
 
   const mockUrl: RevisiumUrlComplete = {
     baseUrl: 'https://cloud.revisium.io',
@@ -52,6 +52,7 @@ describe('ConnectionService', () => {
 
     loggerServiceFake = {
       info: jest.fn(),
+      progress: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -182,7 +183,7 @@ describe('ConnectionService', () => {
         workspaceUrl,
         { createProject: undefined },
       );
-      expect(loggerServiceFake.info).toHaveBeenCalledWith(
+      expect(loggerServiceFake.progress).toHaveBeenCalledWith(
         'Using context local (instance: local)',
       );
     });
@@ -239,7 +240,7 @@ describe('ConnectionService', () => {
           password: undefined,
         },
       );
-      expect(loggerServiceFake.info).toHaveBeenCalledWith(
+      expect(loggerServiceFake.progress).toHaveBeenCalledWith(
         'Using context local (instance: local)',
       );
     });

--- a/src/services/connection/connection.service.ts
+++ b/src/services/connection/connection.service.ts
@@ -110,7 +110,7 @@ export class ConnectionService {
       return;
     }
 
-    this.logger.info(
+    this.logger.progress(
       `Using context ${selectedContext} (instance: ${context.instance})`,
     );
   }

--- a/src/services/workspace/__tests__/workspace-config.service.spec.ts
+++ b/src/services/workspace/__tests__/workspace-config.service.spec.ts
@@ -354,6 +354,17 @@ describe('WorkspaceConfigService', () => {
     );
   });
 
+  it('throws a parse error including the file path when JSON is broken', async () => {
+    const dir = join(tempDir, '.revisium');
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, 'revisium-cli.config.json');
+    await writeFile(path, '{ broken json', 'utf-8');
+
+    await expect(service.load(tempDir)).rejects.toThrow(
+      /Failed to parse Revisium workspace config at .*revisium-cli\.config\.json/,
+    );
+  });
+
   it('writes only the workspace config file when saving', async () => {
     const loaded = await service.loadOrCreate(tempDir);
     loaded.config.instances.local = {

--- a/src/services/workspace/workspace-config.service.ts
+++ b/src/services/workspace/workspace-config.service.ts
@@ -64,7 +64,15 @@ export class WorkspaceConfigService {
     }
 
     const raw = await readFile(configPath, 'utf-8');
-    const parsed = JSON.parse(raw) as unknown;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to parse Revisium workspace config at ${configPath}: ${message}`,
+      );
+    }
 
     return {
       path: configPath,

--- a/src/services/workspace/workspace-config.service.ts
+++ b/src/services/workspace/workspace-config.service.ts
@@ -69,7 +69,7 @@ export class WorkspaceConfigService {
       parsed = JSON.parse(raw);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(
+      throw new TypeError(
         `Failed to parse Revisium workspace config at ${configPath}: ${message}`,
       );
     }


### PR DESCRIPTION
Six CLI source fixes for findings the e2e matrix surfaced when run against `revisium@2.5.0-alpha.0`. All covered by new unit tests.

| Letter | Area | Source change |
|---|---|---|
| **B** | `instance list` / `context list` | accept `--json` (machine-readable output) |
| **C** | `instance remove` | new `--with-credentials` flag clears the saved `default` keyring entry |
| **D** | `instance add` | fails on duplicate name; `--force` overrides |
| **E** | `project ensure` (and rest of `BootstrapService`) | call `assertWritableRevision` before any creation, so head/non-draft contexts fail fast |
| **F** | `LoggerService` + `ConnectionService` | new `progress()` method (→ stderr); route `Using context X (instance: …)` through it so `--json` output is clean JSON on stdout |
| **K** | `WorkspaceConfigService.load` | wrap `JSON.parse` failures with the config path |

## Tests

- `src/commands/instance/__tests__/instance-add.command.spec.ts` — duplicate detection, `--force`, missing args
- `src/commands/instance/__tests__/instance-list.command.spec.ts` — JSON shape, sort order, empty workspace
- `src/commands/instance/__tests__/instance-remove.command.spec.ts` — `--with-credentials` calls keyring, no-ops silently when missing
- `src/commands/context/__tests__/context-list.command.spec.ts` — JSON shape with `current` flag, marker
- `src/services/bootstrap/__tests__/bootstrap.service.spec.ts` — `ensureProject` rejects non-draft target before any creation
- `src/services/workspace/__tests__/workspace-config.service.spec.ts` — broken JSON throws with file path

## Validation

- `npm run tsc` — green
- `npm run lint:ci` — green
- `npm test -- --runInBand` — **337 passing** (was 311 before this PR)

## Out of scope

Failure categories the matrix surfaced but not addressed here:

- A — `auth status` warning routes to stderr (matrix asserts on stdout); CLI behavior is correct
- G — `--token` (JWT) auth against alpha standalone needs separate repro
- H — `sync schema/data/all` no-ops against alpha standalone (separate repro needed)
- I — bootstrap `--dry-run` on populated rootBranch regression (separate repro)
- J — non-TTY prompt error (waits on common-flags `--no-input` PR)
- L — `rows upload --batch` exits 1 (separate repro)
- M — `schema create-migrations` exits 1 (separate repro)
- N — mutually-exclusive auth detection (waits on common-flags PR)

These are tracked in `docs/matrix-alpha-triage.md` (PR #81).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON output for context and instance list commands
  * --force option when adding instances
  * --with-credentials option when removing instances

* **Improvements**
  * Clearer workspace-config parse errors that include the config path
  * Connection/context status emitted as progress to stderr (keeps stdout clean)
  * Listings consistently sorted; bootstrap enforces writable draft revision
  * Best-effort credential deletion logs warnings without failing

* **Tests**
  * Expanded coverage for context, instance, bootstrap, connection, and workspace loading behaviors

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-cli/pull/82)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->