### PR TITLE
docs: slim README + new quickstart, concepts, workflows pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,201 +8,93 @@
 [![GitHub License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/revisium/revisium-cli/blob/master/LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/revisium/revisium-cli)](https://github.com/revisium/revisium-cli/releases)
 
-**Command-line interface for managing Revisium projects**
+**Command-line interface for Revisium** — manage migrations, seed data, and move projects between instances.
 
 </div>
 
-## Overview
+## What is Revisium?
 
-A CLI tool for interacting with Revisium instances, providing migration management, schema export, data export, and project synchronization capabilities.
+A versioned headless CMS / data platform with Git-like branches and revisions. See [revisium.io](https://revisium.io) and [docs.revisium.io](https://docs.revisium.io) for the product reference.
 
-## Features
+This CLI wraps the Revisium HTTP API for everyday CI/CD and developer flows.
 
-- **Migration Management** - Save and apply database migrations with auto-commit
-- **Schema Export/Import** - Export table schemas and convert to migrations
-- **Data Export/Upload** - Export and upload rows with smart dependency handling
-- **Project Sync** - Synchronize schema and data between Revisium projects
-- **Bulk Operations** - Efficient batch operations with configurable batch size
-- **Docker Deployment** - Containerized automation for CI/CD
-
-## Installation
+## Install
 
 ```bash
-# Install globally
-npm install -g revisium
-
-# Or use with npx
-npx revisium --help
+npm install -g revisium      # global
+npx revisium --help          # ad-hoc
 ```
 
-## Examples
-
-### CI/CD Migrations (Prisma-like Workflow)
-
-```
-┌─────────────┐      ┌─────────────┐      ┌─────────────┐
-│    DEV      │      │    GIT      │      │   CI/CD     │
-│             │      │             │      │             │
-│  Revisium   │ save │ migrations  │ push │   apply     │
-│    UI       │─────▶│   .json     │─────▶│  migrations │
-│             │      │   data/     │      │   + seed    │
-└─────────────┘      └─────────────┘      └─────────────┘
-```
-
-Like Prisma, save schema migrations locally and apply them in CI/CD:
+## Quickstart (60 seconds, local)
 
 ```bash
-# 1. Save migrations locally (during development)
-revisium migrate save --file ./revisium/migrations.json \
-  --url revisium://admin:admin@localhost:8080/myorg/myproject/master
+# 1. In one terminal, boot a local Revisium with embedded PostgreSQL.
+npx -y @revisium/standalone --auth     # admin password printed on first run
 
-# 2. Commit to git
-git add revisium/migrations.json
-git commit -m "Add new schema fields"
+# 2. Save your API key once. (Mint a key in the Revisium UI first.)
+revisium auth login --url revisium://localhost:9222 --api-key-stdin
 
-# 3. Apply in CI/CD (on deploy)
-revisium migrate apply --file ./revisium/migrations.json --commit \
-  --url revisium://cloud.revisium.io/myorg/myproject/master
-```
-
-Add to package.json scripts:
-
-```json
-{
-  "scripts": {
-    "revisium:save-migrations": "revisium migrate save --file ./revisium/migrations.json",
-    "revisium:apply-migrations": "revisium migrate apply --file ./revisium/migrations.json --commit",
-    "start:prod": "npm run revisium:apply-migrations && node dist/main"
-  }
-}
-```
-
-See [Docker Deployment](docs/docker-deployment.md) for complete CI/CD examples.
-
-### Export & Import (File-based)
-
-```
-┌─────────────┐                          ┌─────────────┐
-│   SOURCE    │    migrations.json       │   TARGET    │
-│  Revisium   │ ────────────────────▶    │  Revisium   │
-│             │        data/             │             │
-└─────────────┘                          └─────────────┘
-```
-
-Save project to files for backup or deployment to another instance:
-
-```bash
-# Export from source
-revisium migrate save --file ./migrations.json
-revisium rows save --folder ./data
-
-# Import to target
-revisium migrate apply --file ./migrations.json --commit \
-  --url revisium://target.example.com/org/proj/main
-revisium rows upload --folder ./data --commit \
-  --url revisium://target.example.com/org/proj/master
-```
-
-### Sync (Direct Transfer)
-
-```
-┌─────────────┐                          ┌─────────────┐
-│   SOURCE    │    schema + data         │   TARGET    │
-│  Revisium   │ ════════════════════▶    │  Revisium   │
-│             │       (direct)           │   :draft    │
-└─────────────┘                          └─────────────┘
-```
-
-Synchronize directly between two projects without intermediate files:
-
-```bash
-# With tokens in URL
-revisium sync all \
-  --source revisium://source.example.com/org/proj/master:head?token=xxx \
-  --target revisium://target.example.com/org/proj/master?token=yyy \
+# 3. Bootstrap a project + table + row + REST endpoint from one config file.
+revisium example bootstrap \
+  --config ./bootstrap.config.json \
+  --url revisium://localhost:9222/admin/hello/master \
   --commit
 
-# With tokens via environment (recommended for CI/CD)
-export REVISIUM_SOURCE_TOKEN=$SOURCE_TOKEN
-export REVISIUM_TARGET_TOKEN=$TARGET_TOKEN
-revisium sync all \
-  --source revisium://source.example.com/org/proj/master:head \
-  --target revisium://target.example.com/org/proj/master \
-  --commit
+# 4. Hit your fresh REST endpoint.
+curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/Note/first
 ```
+
+Full walkthrough with the `bootstrap.config.json` example: [docs/quickstart.md](docs/quickstart.md).
+
+## Use cases
+
+- **Manage migrations and seeding in CI/CD** — `migrate save/apply` plus `rows upload` for seed data, driven from a JSON file in git. Walk: [docs.revisium.io/migrations/ci-cd](https://docs.revisium.io/migrations/ci-cd).
+- **Sync between live instances** — `sync schema/data/all` copies a project directly between two Revisium instances without intermediate files. Walk: [docs/workflows.md#2-sync-between-two-live-instances](docs/workflows.md#2-sync-between-two-live-instances).
+- **Download / upload (data portability)** — `schema save` / `rows save` / `migrate save` export to JSON; `migrate apply` / `rows upload` import. Useful for backups, fixtures, and air-gapped transfers. Walk: [docs/workflows.md#3-download--upload-data-portability](docs/workflows.md#3-download--upload-data-portability).
 
 ## Commands
 
 | Command                               | Description                            | Documentation                                    |
 | ------------------------------------- | -------------------------------------- | ------------------------------------------------ |
-| `schema save`                         | Export table schemas to JSON files     | [Schema Commands](docs/schema-commands.md)       |
-| `schema create-migrations`            | Convert schemas to migration format    | [Schema Commands](docs/schema-commands.md)       |
 | `migrate save`                        | Export migrations to JSON file         | [Migrate Commands](docs/migrate-commands.md)     |
 | `migrate apply`                       | Apply migrations from JSON file        | [Migrate Commands](docs/migrate-commands.md)     |
+| `schema save`                         | Export table schemas to JSON files     | [Schema Commands](docs/schema-commands.md)       |
+| `schema create-migrations`            | Convert schemas to migration format    | [Schema Commands](docs/schema-commands.md)       |
 | `rows save`                           | Export table data to JSON files        | [Rows Commands](docs/rows-commands.md)           |
 | `rows upload`                         | Upload table data from JSON files      | [Rows Commands](docs/rows-commands.md)           |
 | `sync schema`                         | Sync schema between projects           | [Sync Commands](docs/sync-commands.md)           |
 | `sync data`                           | Sync data between projects             | [Sync Commands](docs/sync-commands.md)           |
 | `sync all`                            | Full sync (schema + data)              | [Sync Commands](docs/sync-commands.md)           |
-| `instance add/list/show/remove`       | Manage workspace Revisium instances    | [Workspace Config](docs/workspace-config.md)     |
-| `context create/list/show/use/remove` | Manage workspace Revisium contexts     | [Workspace Config](docs/workspace-config.md)     |
-| `auth login/status/logout`            | Manage saved API-key credentials       | [Authentication](docs/authentication.md)         |
 | `project ensure`                      | Ensure a project and branch exist      | [Bootstrap Commands](docs/bootstrap-commands.md) |
 | `endpoint ensure/list`                | Ensure or list generated endpoints     | [Bootstrap Commands](docs/bootstrap-commands.md) |
-| `example bootstrap`                   | Bootstrap example projects from config | [Bootstrap Commands](docs/bootstrap-commands.md) |
+| `example bootstrap`                   | Bootstrap a project from config        | [Bootstrap Commands](docs/bootstrap-commands.md) |
+| `auth login/status/logout`            | Manage saved API-key credentials       | [Authentication](docs/authentication.md)         |
+| `instance add/list/show/remove`       | Manage workspace Revisium instances    | [Workspace Config](docs/workspace-config.md)     |
+| `context create/list/show/use/remove` | Manage workspace Revisium contexts     | [Workspace Config](docs/workspace-config.md)     |
 
 ## Configuration
 
-Configure via workspace config, environment variables, or `.env` file:
+Pick the auth method that matches the context:
 
-```bash
-# Workspace-local standalone example without auth
-revisium instance add local --url revisium://localhost:9222 --auth none
-revisium context create dictionary-local \
-  --url revisium://localhost:9222/admin/dictionary/master
-revisium context use dictionary-local
-```
+- **Saved API key** — recommended for local dev. Run `revisium auth login` once; the key lives in the OS keyring and is reused automatically.
+- **Environment variables** — recommended for CI. `REVISIUM_TOKEN` (or `REVISIUM_API_KEY`) plus `REVISIUM_URL`.
+- **Workspace contexts** — for multi-target setups. `revisium instance add` and `revisium context create` save non-secret config under `.revisium/revisium-cli.config.json`.
 
-Then single-target commands can omit `--url` in that workspace.
-
-```env
-# Recommended: URL + Token
-REVISIUM_URL=revisium://cloud.revisium.io/your_org/your_project/main
-REVISIUM_TOKEN=your_jwt_token
-
-# Alternative: URL + Username/Password
-REVISIUM_URL=revisium://cloud.revisium.io/your_org/your_project/main
-REVISIUM_USERNAME=your_username
-REVISIUM_PASSWORD=your_password
-```
-
-Or use command-line `--url` option with credentials via environment:
-
-```bash
-# Token in environment, target in URL
-export REVISIUM_TOKEN=$MY_TOKEN
-revisium schema save --folder ./schemas \
-  --url revisium://cloud.revisium.io/my-org/my-project/develop
-
-# Token in URL query parameter
-revisium schema save --folder ./schemas \
-  --url revisium://cloud.revisium.io/my-org/my-project/develop?token=$TOKEN
-```
-
-See [Configuration](docs/configuration.md) and [URL Format](docs/url-format.md) for details.
+Full precedence rules and every supported method: [docs/authentication.md](docs/authentication.md), [docs/configuration.md](docs/configuration.md).
 
 ## Documentation
 
-- [Configuration](docs/configuration.md) - Environment variables and .env files
-- [Workspace Config](docs/workspace-config.md) - non-secret instances and contexts
-- [Bootstrap Commands](docs/bootstrap-commands.md) - project, endpoint, and example bootstrap workflows
-- [URL Format](docs/url-format.md) - Revisium URL syntax
-- [Authentication](docs/authentication.md) - Token, API key, and password auth
-- [Schema Commands](docs/schema-commands.md) - schema save, create-migrations
-- [Migrate Commands](docs/migrate-commands.md) - migrate save, apply
-- [Rows Commands](docs/rows-commands.md) - rows save, upload
-- [Sync Commands](docs/sync-commands.md) - sync schema, data, all
-- [Docker Deployment](docs/docker-deployment.md) - Docker, Kubernetes, CI/CD
+- [Quickstart](docs/quickstart.md) — run the CLI against a local Revisium in five minutes.
+- [Concepts](docs/concepts.md) — primitives the CLI works with.
+- [Common workflows](docs/workflows.md) — named recipes (CI/CD, sync, portability).
+- [Authentication](docs/authentication.md) · [Configuration](docs/configuration.md) · [URL Format](docs/url-format.md) · [Workspace Config](docs/workspace-config.md)
+- Per-command: [migrate](docs/migrate-commands.md) · [schema](docs/schema-commands.md) · [rows](docs/rows-commands.md) · [sync](docs/sync-commands.md) · [bootstrap](docs/bootstrap-commands.md)
+- [Docker deployment](docs/docker-deployment.md)
+- Product docs: [docs.revisium.io](https://docs.revisium.io)
+
+## Compatibility
+
+CLI 2.5.x targets `@revisium/standalone` 2.8.x and current `cloud.revisium.io`.
 
 ## Development
 
@@ -213,6 +105,8 @@ npm install
 npm run build
 ```
 
+Conventions and the verify checklist for contributors are in [AGENTS.md](AGENTS.md).
+
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -29,22 +29,20 @@ npx revisium --help          # ad-hoc
 
 ```bash
 # 1. In one terminal, boot a local Revisium with embedded PostgreSQL.
-npx -y @revisium/standalone --auth     # admin password printed on first run
+#    No --auth flag = no credentials needed for the rest of this quickstart.
+npx -y @revisium/standalone
 
-# 2. Save your API key once. (Mint a key in the Revisium UI first.)
-revisium auth login --url revisium://localhost:9222 --api-key-stdin
-
-# 3. Bootstrap a project + table + row + REST endpoint from one config file.
+# 2. Bootstrap a project + table + row + REST endpoint from one config file.
 revisium example bootstrap \
   --config ./bootstrap.config.json \
   --url revisium://localhost:9222/admin/hello/master \
   --commit
 
-# 4. Hit your fresh REST endpoint.
+# 3. Hit your fresh REST endpoint.
 curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/Note/first
 ```
 
-Full walkthrough with the `bootstrap.config.json` example: [docs/quickstart.md](docs/quickstart.md).
+Full walkthrough with the `bootstrap.config.json` example: [docs/quickstart.md](docs/quickstart.md). For a Revisium that requires login, see [docs/authentication.md](docs/authentication.md).
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -28,21 +28,24 @@ npx revisium --help          # ad-hoc
 ## Quickstart (60 seconds, local)
 
 ```bash
-# 1. In one terminal, boot a local Revisium with embedded PostgreSQL.
+# 1. Boot a local Revisium with embedded PostgreSQL in another terminal.
 #    No --auth flag = no credentials needed for the rest of this quickstart.
 npx -y @revisium/standalone
 
-# 2. Bootstrap a project + table + row + REST endpoint from one config file.
+# 2. Grab the example bootstrap config (or write your own — see docs/quickstart.md).
+curl -O https://raw.githubusercontent.com/revisium/revisium-cli/master/examples/quickstart/bootstrap.config.json
+
+# 3. Bootstrap a project + table + row + REST endpoint.
 revisium example bootstrap \
   --config ./bootstrap.config.json \
   --url revisium://localhost:9222/admin/hello/master \
   --commit
 
-# 3. Hit your fresh REST endpoint.
+# 4. Hit your fresh REST endpoint.
 curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/Note/first
 ```
 
-Full walkthrough with the `bootstrap.config.json` example: [docs/quickstart.md](docs/quickstart.md). For a Revisium that requires login, see [docs/authentication.md](docs/authentication.md).
+Full walkthrough: [docs/quickstart.md](docs/quickstart.md). For a Revisium that requires login, see [docs/authentication.md](docs/authentication.md).
 
 ## Use cases
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Full precedence rules and every supported method: [docs/authentication.md](docs/
 
 ## Compatibility
 
-CLI 2.5.x targets `@revisium/standalone` 2.8.x and current `cloud.revisium.io`.
+The current CLI targets `@revisium/standalone` 2.8.x and current `cloud.revisium.io`.
 
 ## Development
 

--- a/docs/bootstrap-commands.md
+++ b/docs/bootstrap-commands.md
@@ -58,7 +58,20 @@ revisium example bootstrap \
   --commit
 ```
 
-Config shape:
+### Config schema
+
+`bootstrap.config.json` describes a complete project bootstrap. All fields are optional except where marked.
+
+| Field           | Type                       | Notes                                                                                       |
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------------- |
+| `projectName`   | string                     | Asserted against the target URL's `<project>` segment when set; mismatches fail fast.       |
+| `branchName`    | string                     | Same idea for the branch segment.                                                           |
+| `endpoints`     | array of `"REST_API"` / `"GRAPHQL"` | Endpoints to ensure on the target revision. `--endpoint` flags override this array. |
+| `tables`        | array of `{ id, schema }`  | `id`: non-empty string; `schema`: a JSON Schema object (`type: "object"` with properties).  |
+| `rows`          | array of `{ tableId, rowId, data }` | All three fields required and non-empty; `data` must be an object.                 |
+| `commitMessage` | string                     | Used as the revision message when `--commit` is passed.                                     |
+
+A complete example:
 
 ```json
 {
@@ -66,14 +79,35 @@ Config shape:
   "branchName": "master",
   "endpoints": ["REST_API", "GRAPHQL"],
   "tables": [
-    { "id": "FaqCategory", "schema": { "type": "object" } }
+    {
+      "id": "FaqCategory",
+      "schema": {
+        "type": "object",
+        "required": ["name"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "default": "" },
+          "summary": { "type": "string", "default": "" }
+        }
+      }
+    }
   ],
   "rows": [
-    { "tableId": "FaqCategory", "rowId": "billing", "data": { "name": "Billing" } }
+    {
+      "tableId": "FaqCategory",
+      "rowId": "billing",
+      "data": { "name": "Billing", "summary": "Payments and invoices" }
+    }
   ],
   "commitMessage": "Bootstrap dictionary example"
 }
 ```
+
+Notes on table schemas:
+
+- Revisium accepts JSON Schema with `type: "object"` at the root.
+- Use `type: "number"` for numeric fields — `type: "integer"` is rejected as "this type is not allowed".
+- `additionalProperties: false` and per-property `default` values are recommended; rows lacking a field will fail validation otherwise.
 
 Behavior:
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -32,7 +32,7 @@ A workspace can hold many instances and contexts, with one **current context** t
 
 ## How they fit together
 
-```
+```text
 revisium-cli.config.json               OS keyring                  Revisium server
 ─────────────────────────               ──────────                  ───────────────
 instances.local                                                    revisium://localhost:9222

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -44,11 +44,13 @@ currentContext: dictionary-local
 
 When you run `revisium <command>`, the CLI resolves a target in this precedence order:
 
-1. Explicit flags: `--url`, `--context`, `--token`, `--api-key`, `--api-key-stdin`.
+1. Explicit flags: `--url`, `--context`, `--token`.
 2. URL-embedded auth: `?token=…`, `?apikey=…`, `user:password@host`.
 3. Environment: `REVISIUM_URL`, `REVISIUM_TOKEN`, `REVISIUM_API_KEY`, `REVISIUM_USERNAME` / `REVISIUM_PASSWORD`.
 4. The current workspace context (if any), with its saved credential from the OS keyring.
 5. Interactive prompt — only when stdin is a TTY.
+
+(`--api-key` and `--api-key-stdin` are inputs to `auth login` itself — they tell the CLI which key to *save*, not which key the next command should use.)
 
 `auth login` saves a credential under `service: revisium-cli, account: instance:<baseUrl>|credential:<name>`. `auth logout` removes it.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,61 @@
+# Concepts
+
+The CLI works with two layers of primitives: **product concepts** (defined by Revisium itself, the same on every client) and **CLI primitives** (workspace-level helpers that exist only in this tool's config).
+
+## Product concepts
+
+These describe how Revisium models data on the server. The CLI accepts and produces them but doesn't define them — see [docs.revisium.io](https://docs.revisium.io) for the canonical reference.
+
+| Concept    | One-liner                                                                                              |
+| ---------- | ------------------------------------------------------------------------------------------------------ |
+| Organization | Top-level tenant (e.g. `admin`).                                                                     |
+| Project    | A collection of branches owned by an organization.                                                     |
+| Branch     | A line of revisions, like a Git branch (default: `master`).                                            |
+| Revision   | An immutable snapshot of all tables and rows. A branch points at a `head` revision and a `draft`.      |
+| Table      | A typed collection of rows; the schema is JSON Schema.                                                 |
+| Row        | One record in a table, identified by `rowId`.                                                          |
+| Endpoint   | A generated REST or GraphQL surface exposing one revision.                                             |
+
+A Revisium target on the wire is `revisium://host[:port]/<org>/<project>/<branch>[:<revision>]`. The CLI parses this format anywhere a `--url` flag is accepted; see [URL Format](url-format.md).
+
+## CLI primitives
+
+These are workspace-local conveniences saved in `.revisium/revisium-cli.config.json`. They don't exist on the server.
+
+| Primitive  | What it is                                                                                                                | Stored?                                              |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Instance   | An alias for a Revisium server (`local`, `cloud`, `staging`, …) — base URL plus an auth mode (`none` or `stored`).         | Workspace config (non-secret).                       |
+| Context    | A default target inside an instance — organization, project, branch, optional revision and credential name.               | Workspace config (non-secret).                       |
+| Credential | A named API key for an instance (default name is `default`).                                                              | OS keyring via `revisium auth login`. Never on disk. |
+
+A workspace can hold many instances and contexts, with one **current context** that single-target commands use when neither `--url` nor `--context` is passed.
+
+## How they fit together
+
+```
+revisium-cli.config.json               OS keyring                  Revisium server
+─────────────────────────               ──────────                  ───────────────
+instances.local                                                    revisium://localhost:9222
+└─ baseUrl, authMode "stored"           credential "default" ──→   bearer / X-Api-Key
+contexts.dictionary-local                                          /admin/dictionary/master:draft
+└─ instance, organization, project, branch, revision, credential
+currentContext: dictionary-local
+```
+
+When you run `revisium <command>`, the CLI resolves a target in this precedence order:
+
+1. Explicit flags: `--url`, `--context`, `--token`, `--api-key`, `--api-key-stdin`.
+2. URL-embedded auth: `?token=…`, `?apikey=…`, `user:password@host`.
+3. Environment: `REVISIUM_URL`, `REVISIUM_TOKEN`, `REVISIUM_API_KEY`, `REVISIUM_USERNAME` / `REVISIUM_PASSWORD`.
+4. The current workspace context (if any), with its saved credential from the OS keyring.
+5. Interactive prompt — only when stdin is a TTY.
+
+`auth login` saves a credential under `service: revisium-cli, account: instance:<baseUrl>|credential:<name>`. `auth logout` removes it.
+
+## Where to read next
+
+- [Quickstart](quickstart.md) — boot a local Revisium and run the CLI against it.
+- [Common workflows](workflows.md) — named recipes for migrations, sync, and portability.
+- [Workspace Config](workspace-config.md) — the full file shape and discovery rules.
+- [Authentication](authentication.md) — every supported auth method, with priority and remediation hints.
+- [URL Format](url-format.md) — the `revisium://` URL grammar.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ Boots a local Revisium with no authentication, creates a project with a table an
 - Node.js 20 or later.
 - A free terminal window for the local Revisium server.
 
-The CLI itself is `npx`-friendly, so you don't need to install it globally to follow along.
+The CLI is `npx`-friendly, so you don't need to install it globally to follow along; if you don't install it, prefix the commands below with `npx`, for example `npx revisium example bootstrap …`.
 
 ## 1. Boot a local Revisium (no-auth)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Boots a local Revisium, creates a project with a table and a row, and exposes it as a REST endpoint — all from the CLI. Should take under five minutes from a clean checkout.
+Boots a local Revisium with no authentication, creates a project with a table and a row, and exposes it as a REST endpoint — all from the CLI. Should take under five minutes from a clean checkout.
 
 ## Prerequisites
 
@@ -9,34 +9,21 @@ Boots a local Revisium, creates a project with a table and a row, and exposes it
 
 The CLI itself is `npx`-friendly, so you don't need to install it globally to follow along.
 
-## 1. Boot a local Revisium
+## 1. Boot a local Revisium (no-auth)
 
 In one terminal:
 
 ```bash
-npx -y @revisium/standalone --auth
+npx -y @revisium/standalone
 ```
 
-`@revisium/standalone` is a self-contained Revisium with embedded PostgreSQL. The first run prints an admin password — copy it. Subsequent runs print the bound URL (default: `http://localhost:9222`).
+`@revisium/standalone` is a self-contained Revisium with embedded PostgreSQL. Without the `--auth` flag it runs in **no-auth mode**: anyone hitting `http://localhost:9222` can read and write. Perfect for kicking the tires; do not expose this to the internet.
 
-Leave this terminal running.
+Leave this terminal running. The bound URL appears in the banner once startup finishes.
 
-## 2. Save your API key
+For the auth-enabled path (`--auth` plus `revisium auth login`), see [docs/authentication.md](authentication.md).
 
-In a second terminal, log in once. The CLI stores the key in your OS keyring so later commands don't need it again:
-
-```bash
-# Open Revisium's UI in a browser, sign in with the admin password, and mint
-# a personal API key under "API Keys". Then:
-revisium auth login \
-  --url revisium://localhost:9222 \
-  --api-key-stdin
-# (paste the API key, then Enter)
-```
-
-`revisium auth status --url revisium://localhost:9222` will confirm the credential is saved.
-
-## 3. Bootstrap a project
+## 2. Bootstrap a project
 
 Save this as `bootstrap.config.json`:
 
@@ -82,7 +69,7 @@ The CLI:
 4. Generates a `REST_API` endpoint pointing at the new revision.
 5. Commits the draft, sealing the revision.
 
-## 4. Hit the REST endpoint
+## 3. Hit the REST endpoint
 
 ```bash
 curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/Note/first
@@ -101,7 +88,8 @@ You're done. The same shape — bootstrap config + example bootstrap command —
 If you'll keep running the CLI in this directory, add a workspace context so commands can omit `--url`:
 
 ```bash
-revisium instance add local --url revisium://localhost:9222
+# --auth none matches the standalone we booted in step 1
+revisium instance add local --url revisium://localhost:9222 --auth none
 revisium context create hello-local \
   --url revisium://localhost:9222/admin/hello/master
 revisium context use hello-local

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,121 @@
+# Quickstart
+
+Boots a local Revisium, creates a project with a table and a row, and exposes it as a REST endpoint — all from the CLI. Should take under five minutes from a clean checkout.
+
+## Prerequisites
+
+- Node.js 20 or later.
+- A free terminal window for the local Revisium server.
+
+The CLI itself is `npx`-friendly, so you don't need to install it globally to follow along.
+
+## 1. Boot a local Revisium
+
+In one terminal:
+
+```bash
+npx -y @revisium/standalone --auth
+```
+
+`@revisium/standalone` is a self-contained Revisium with embedded PostgreSQL. The first run prints an admin password — copy it. Subsequent runs print the bound URL (default: `http://localhost:9222`).
+
+Leave this terminal running.
+
+## 2. Save your API key
+
+In a second terminal, log in once. The CLI stores the key in your OS keyring so later commands don't need it again:
+
+```bash
+# Open Revisium's UI in a browser, sign in with the admin password, and mint
+# a personal API key under "API Keys". Then:
+revisium auth login \
+  --url revisium://localhost:9222 \
+  --api-key-stdin
+# (paste the API key, then Enter)
+```
+
+`revisium auth status --url revisium://localhost:9222` will confirm the credential is saved.
+
+## 3. Bootstrap a project
+
+Save this as `bootstrap.config.json`:
+
+```json
+{
+  "projectName": "hello",
+  "branchName": "master",
+  "endpoints": ["REST_API"],
+  "tables": [
+    {
+      "id": "Note",
+      "schema": {
+        "type": "object",
+        "required": ["text"],
+        "additionalProperties": false,
+        "properties": {
+          "text": { "type": "string", "default": "" }
+        }
+      }
+    }
+  ],
+  "rows": [
+    { "tableId": "Note", "rowId": "first", "data": { "text": "hi" } }
+  ],
+  "commitMessage": "Initial bootstrap"
+}
+```
+
+Run it:
+
+```bash
+revisium example bootstrap \
+  --config ./bootstrap.config.json \
+  --url revisium://localhost:9222/admin/hello/master \
+  --commit
+```
+
+The CLI:
+
+1. Creates the `hello` project (idempotent — re-runs report `skipped`).
+2. Creates the `Note` table with the JSON Schema above.
+3. Creates a `first` row.
+4. Generates a `REST_API` endpoint pointing at the new revision.
+5. Commits the draft, sealing the revision.
+
+## 4. Hit the REST endpoint
+
+```bash
+curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/Note/first
+```
+
+Expected response:
+
+```json
+{ "text": "hi" }
+```
+
+You're done. The same shape — bootstrap config + example bootstrap command — scales up to many tables, rows, and endpoints.
+
+## Optional: pin the workspace
+
+If you'll keep running the CLI in this directory, add a workspace context so commands can omit `--url`:
+
+```bash
+revisium instance add local --url revisium://localhost:9222
+revisium context create hello-local \
+  --url revisium://localhost:9222/admin/hello/master
+revisium context use hello-local
+
+# Subsequent commands resolve the target from the current context
+revisium project ensure --json
+revisium endpoint list --json
+```
+
+`.revisium/revisium-cli.config.json` is non-secret and safe to commit when shared by a team.
+
+## Next
+
+- [Concepts](concepts.md) — what the primitives mean.
+- [Common workflows](workflows.md) — migrations + seeding, sync, portability.
+- [Authentication](authentication.md) — all supported auth methods.
+- [Bootstrap commands](bootstrap-commands.md) — full `bootstrap.config.json` schema and command flags.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,7 +25,13 @@ For the auth-enabled path (`--auth` plus `revisium auth login`), see [docs/authe
 
 ## 2. Bootstrap a project
 
-Save this as `bootstrap.config.json`:
+Grab the example config from this repo:
+
+```bash
+curl -O https://raw.githubusercontent.com/revisium/revisium-cli/master/examples/quickstart/bootstrap.config.json
+```
+
+Or write your own — full schema in [bootstrap commands](bootstrap-commands.md#config-schema). For reference, the file you just downloaded:
 
 ```json
 {
@@ -48,7 +54,7 @@ Save this as `bootstrap.config.json`:
   "rows": [
     { "tableId": "Note", "rowId": "first", "data": { "text": "hi" } }
   ],
-  "commitMessage": "Initial bootstrap"
+  "commitMessage": "Quickstart bootstrap"
 }
 ```
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,100 @@
+# Common workflows
+
+Three named recipes for the things teams use the CLI for in production. Each one is the runnable command sequence; deeper detail lives in the per-command docs.
+
+## 1. Manage migrations and seeding in CI/CD
+
+The canonical flow: schema changes are made in dev, exported to JSON, committed to git, then applied through staging and prod by an automated pipeline. **The full walk-through lives in the product docs at [docs.revisium.io/migrations/ci-cd](https://docs.revisium.io/migrations/ci-cd).**
+
+CLI summary:
+
+```bash
+# 1. In dev, after editing schema in the UI:
+revisium migrate save --file ./revisium/migrations.json \
+  --url revisium://localhost:9222/myorg/myproject/master
+
+# (optional) export seed data
+revisium rows save --folder ./revisium/data \
+  --url revisium://localhost:9222/myorg/myproject/master
+
+git add revisium/ && git commit -m "Add new schema fields"
+
+# 2. In CI, against an environment:
+export REVISIUM_TOKEN=$STAGING_TOKEN
+revisium migrate apply --file ./revisium/migrations.json --commit \
+  --url revisium://staging.example.com/myorg/myproject/master
+
+# (optional) seed data on first deploy
+revisium rows upload --folder ./revisium/data --commit \
+  --url revisium://staging.example.com/myorg/myproject/master
+```
+
+Key flags:
+
+- `--commit` seals a new revision after the apply / upload finishes.
+- `--create-project` on `migrate apply` creates the project if it doesn't exist (useful for ephemeral preview environments).
+
+In CI, prefer `REVISIUM_TOKEN` (env) over `?token=` in the URL — token doesn't end up in shell history or process listings.
+
+See [migrate commands](migrate-commands.md) and [docs.revisium.io/migrations/ci-cd](https://docs.revisium.io/migrations/ci-cd).
+
+## 2. Sync between two live instances
+
+Direct project-to-project transfer with no intermediate files. Useful for refreshing staging from prod, or copying a fixture project across regions.
+
+```bash
+export REVISIUM_SOURCE_TOKEN=$PROD_READ_TOKEN
+export REVISIUM_TARGET_TOKEN=$STAGING_WRITE_TOKEN
+
+# Schema only
+revisium sync schema \
+  --source revisium://prod.example.com/myorg/myproject/master:head \
+  --target revisium://staging.example.com/myorg/myproject/master \
+  --commit
+
+# Schema + data
+revisium sync all \
+  --source revisium://prod.example.com/myorg/myproject/master:head \
+  --target revisium://staging.example.com/myorg/myproject/master \
+  --commit
+```
+
+Notes:
+
+- The source target should usually point at `:head` (a sealed revision); the target writes to `:draft` and `--commit` seals the result.
+- `sync data` skips schema differences — run `sync schema` first when schemas have drifted.
+- Per-side env vars (`REVISIUM_SOURCE_*` / `REVISIUM_TARGET_*`) take precedence over the generic `REVISIUM_*` ones.
+
+See [sync commands](sync-commands.md).
+
+## 3. Download / upload (data portability)
+
+File-based variant of the same idea — useful for backups, fixtures stored in git, or transferring through environments without direct network access.
+
+```bash
+# Download (export) from one instance:
+revisium migrate save --file ./out/migrations.json   # schema as migrations
+revisium schema  save --folder ./out/schemas         # raw JSON schemas
+revisium rows    save --folder ./out/data            # row data
+
+# Upload (import) to another instance:
+revisium migrate apply  --file ./out/migrations.json --commit
+revisium rows    upload --folder ./out/data        --commit
+```
+
+Variants:
+
+- `schema save` + `schema create-migrations` is the offline path: read schemas from JSON files and produce a migration JSON without touching the network. Use it when you author schema in editor tooling instead of the UI.
+- `--batch-size <n>` on `rows upload` keeps memory bounded for large fixtures.
+- For a one-off bootstrap (project + tables + rows + endpoints from a single config), see `example bootstrap` in [bootstrap commands](bootstrap-commands.md).
+
+See [schema commands](schema-commands.md), [rows commands](rows-commands.md), and [migrate commands](migrate-commands.md).
+
+## When to pick which
+
+| Scenario                                                  | Use                                                                  |
+| --------------------------------------------------------- | -------------------------------------------------------------------- |
+| Schema lives in code, prod is the next stop after staging | **Migrations in CI/CD** — git is the source of truth                 |
+| Refresh non-prod from prod, prod stays canonical          | **Sync** — direct, no intermediate files                             |
+| Snapshot data for git, compliance, or air-gapped transfer | **Download / upload** — file-based                                   |
+| First-time setup of a brand-new project                   | **`example bootstrap`** — one config file, idempotent                |

--- a/examples/quickstart/bootstrap.config.json
+++ b/examples/quickstart/bootstrap.config.json
@@ -1,0 +1,22 @@
+{
+  "projectName": "hello",
+  "branchName": "master",
+  "endpoints": ["REST_API"],
+  "tables": [
+    {
+      "id": "Note",
+      "schema": {
+        "type": "object",
+        "required": ["text"],
+        "additionalProperties": false,
+        "properties": {
+          "text": { "type": "string", "default": "" }
+        }
+      }
+    }
+  ],
+  "rows": [
+    { "tableId": "Note", "rowId": "first", "data": { "text": "hi" } }
+  ],
+  "commitMessage": "Quickstart bootstrap"
+}


### PR DESCRIPTION
## Summary

Slims the README from 218 -> 112 lines so it reads as a front door, and pushes detail into focused pages under `docs/`.

## README rewrite

- single Quickstart against `@revisium/standalone`
- three use-case bullets — CI/CD migrations, sync, download/upload — each linking to a runnable recipe rather than duplicating content
- command table grouped by purpose (data ops, sync, ensure, auth, workspace)
- canonical auth path is saved API key for local dev / `REVISIUM_TOKEN` env for CI; the discouraged `user:password@host` example is dropped

## New docs

- `docs/quickstart.md` — full local walk: standalone -> `auth login` -> `example bootstrap` -> `curl` against the generated REST endpoint
- `docs/concepts.md` — thin bridge between docs.revisium.io product concepts (project / branch / revision / endpoint) and CLI-only primitives (instance / context / credential), plus the auth precedence chain
- `docs/workflows.md` — named recipes for the three use cases the README highlights; the CI/CD recipe defers to docs.revisium.io rather than duplicating it

## Updated docs

- `docs/bootstrap-commands.md` — fuller `bootstrap.config.json` schema with field-level table and practical schema notes (`type: number`, `additionalProperties`).

## Validation

- `npm run tsc` clean
- `npm run lint:ci` clean (no source changes)
- All existing markdown links in the touched files resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined README with clearer install, commands, use cases, compatibility, and auth-precedence guidance
  * New 60‑second quickstart showing local standalone boot, example bootstrap, and calling the generated REST endpoint
  * Expanded bootstrap docs with full config schema and a complete JSON example
  * New concepts doc explaining CLI primitives, target URL format, and credential resolution order
  * Added production workflow guides for migrations, live-instance sync, and file-based portability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-cli/pull/84)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->