### PR TITLE
fix: --skip-auth + share resolved client + correct quickstart URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ npx -y @revisium/standalone
 curl -O https://raw.githubusercontent.com/revisium/revisium-cli/master/examples/quickstart/bootstrap.config.json
 
 # 3. Bootstrap a project + table + row + REST endpoint.
+#    --skip-auth tells the CLI not to ask for credentials against this no-auth standalone.
 revisium example bootstrap \
   --config ./bootstrap.config.json \
   --url revisium://localhost:9222/admin/hello/master \
+  --skip-auth \
   --commit
 
 # 4. Hit your fresh REST endpoint.
-curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/Note/first
+curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/tables/Note/row/first
 ```
 
 Full walkthrough: [docs/quickstart.md](docs/quickstart.md). For a Revisium that requires login, see [docs/authentication.md](docs/authentication.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -64,8 +64,11 @@ Run it:
 revisium example bootstrap \
   --config ./bootstrap.config.json \
   --url revisium://localhost:9222/admin/hello/master \
+  --skip-auth \
   --commit
 ```
+
+`--skip-auth` tells the CLI not to look for credentials. Without it, the CLI assumes the target requires auth and prompts interactively (or fails in CI). Drop the flag the moment you point at a `--auth`-enabled Revisium.
 
 The CLI:
 
@@ -78,14 +81,24 @@ The CLI:
 ## 3. Hit the REST endpoint
 
 ```bash
-curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/Note/first
+curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/tables/Note/row/first
 ```
 
-Expected response:
+Expected response (formatted):
 
 ```json
-{ "text": "hi" }
+{
+  "id": "first",
+  "data": { "text": "hi" },
+  "versionId": "…",
+  "createdAt": "…",
+  "updatedAt": "…",
+  "publishedAt": "…",
+  "readonly": true
+}
 ```
+
+The endpoint base URL is `<host>/endpoint/rest/<org>/<project>/<branch>/<revision>`. Underneath it, `/tables/<tableId>` lists rows and `/tables/<tableId>/row/<rowId>` returns one row.
 
 You're done. The same shape — bootstrap config + example bootstrap command — scales up to many tables, rows, and endpoints.
 

--- a/src/commands/base.command.ts
+++ b/src/commands/base.command.ts
@@ -1,9 +1,11 @@
 import { CommandRunner, Option } from 'nest-commander';
+import { parseBooleanOption } from 'src/utils/parse-boolean.utils';
 
 export type BaseOptions = {
   url?: string;
   context?: string;
   token?: string;
+  skipAuth?: boolean;
 };
 
 export abstract class BaseCommand extends CommandRunner {
@@ -35,5 +37,15 @@ export abstract class BaseCommand extends CommandRunner {
   })
   public parseToken(value: string) {
     return value;
+  }
+
+  @Option({
+    flags: '--skip-auth [boolean]',
+    description:
+      'Treat the target as unauthenticated (e.g. a local @revisium/standalone booted without --auth). Skips the credential prompt.',
+    required: false,
+  })
+  public parseSkipAuth(value?: string): boolean {
+    return parseBooleanOption(value);
   }
 }

--- a/src/commands/example/example-bootstrap.command.ts
+++ b/src/commands/example/example-bootstrap.command.ts
@@ -37,6 +37,8 @@ export class ExampleBootstrapCommand extends BaseCommand {
     const summary = await this.bootstrapService.bootstrapExample({
       url: options.url,
       context: options.context,
+      token: options.token,
+      skipAuth: options.skipAuth,
       configPath: options.config,
       commit: options.commit,
       dryRun: options.dryRun,

--- a/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
+++ b/src/services/bootstrap/__tests__/bootstrap.service.spec.ts
@@ -504,6 +504,24 @@ describe('BootstrapService', () => {
       );
     });
 
+    it('resolves the connection only once per bootstrap (no double prompt)', async () => {
+      const configPath = await writeBootstrapConfig({
+        tables: [],
+        rows: [],
+      });
+      revisionScopeFake.getEndpoints.mockResolvedValue([]);
+
+      await service.bootstrapExample({
+        url: 'revisium://local',
+        configPath,
+      });
+
+      // ensureProject is invoked internally with the already-resolved
+      // client, so connectionService.resolveTarget should fire exactly once
+      // even though both bootstrapExample and ensureProject normally call it.
+      expect(connectionServiceFake.resolveTarget).toHaveBeenCalledTimes(1);
+    });
+
     it('reports row conflicts and stops without writing', async () => {
       const configPath = await writeBootstrapConfig({
         tables: [],

--- a/src/services/bootstrap/bootstrap.service.ts
+++ b/src/services/bootstrap/bootstrap.service.ts
@@ -10,6 +10,8 @@ export type EndpointType = 'REST_API' | 'GRAPHQL';
 export interface TargetOptions {
   url?: string;
   context?: string;
+  token?: string;
+  skipAuth?: boolean;
 }
 
 export interface ProjectEnsureResult {
@@ -99,8 +101,10 @@ export class BootstrapService {
   async ensureProject(
     options: TargetOptions,
     dryRun = false,
+    resolved?: ResolvedClient,
   ): Promise<ProjectEnsureResult> {
-    const { url, apiClient } = await this.createResolvedClient(options);
+    const { url, apiClient } =
+      resolved ?? (await this.createResolvedClient(options));
     this.assertWritableRevision(url);
     const branchName = url.branch || 'master';
     const orgScope = apiClient.client.org(url.organization);
@@ -224,7 +228,12 @@ export class BootstrapService {
       this.assertBranchNameMatchesTarget(config, url, false);
     }
 
-    const project = await this.ensureProject(options, dryRun);
+    // Reuse the resolved client so we don't re-prompt for auth or re-resolve
+    // the workspace context in ensureProject.
+    const project = await this.ensureProject(options, dryRun, {
+      url,
+      apiClient,
+    });
 
     // In dry-run, allow a branchName mismatch only for the specific
     // populated-rootBranch regression case: project already exists, target

--- a/src/services/connection/__tests__/connection.service.spec.ts
+++ b/src/services/connection/__tests__/connection.service.spec.ts
@@ -338,6 +338,31 @@ describe('ConnectionService', () => {
       );
     });
 
+    it('passes noAuth env when --skip-auth is set and ignores credential env vars', async () => {
+      const testUrl = 'revisium://localhost:9222/admin/hello/master';
+      configServiceFake.get.mockImplementation((key: string) =>
+        key === 'REVISIUM_URL' ? 'env-url' : 'env-token',
+      );
+
+      urlBuilderServiceFake.parseAndComplete.mockRejectedValue(
+        new Error('test error'),
+      );
+
+      await expect(
+        service.connect({ url: testUrl, skipAuth: true }),
+      ).rejects.toThrow();
+
+      expect(urlBuilderServiceFake.parseAndComplete).toHaveBeenCalledWith(
+        testUrl,
+        'api',
+        { url: 'env-url', noAuth: true },
+      );
+      expect(configServiceFake.get).not.toHaveBeenCalledWith('REVISIUM_TOKEN');
+      expect(configServiceFake.get).not.toHaveBeenCalledWith(
+        'REVISIUM_API_KEY',
+      );
+    });
+
     it('calls connectionFactory.createConnection with parsed url', async () => {
       urlBuilderServiceFake.parseAndComplete.mockResolvedValue(mockUrl);
       connectionFactoryFake.createConnection.mockResolvedValue(

--- a/src/services/connection/connection.service.ts
+++ b/src/services/connection/connection.service.ts
@@ -15,6 +15,7 @@ export interface ConnectionOptions {
   url?: string;
   context?: string;
   token?: string;
+  skipAuth?: boolean;
   createProject?: boolean;
 }
 
@@ -118,6 +119,11 @@ export class ConnectionService {
 
   private getEnvConfig(options: ConnectionOptions = {}): UrlEnvConfig {
     const url = this.configService.get<string>('REVISIUM_URL');
+
+    if (options.skipAuth) {
+      return { url, noAuth: true };
+    }
+
     const token =
       options.token ?? this.configService.get<string>('REVISIUM_TOKEN');
 

--- a/src/services/url/__tests__/url-builder.service.spec.ts
+++ b/src/services/url/__tests__/url-builder.service.spec.ts
@@ -242,6 +242,18 @@ describe('UrlBuilderService', () => {
       }
     });
 
+    it('returns method "none" without prompting when env.noAuth is set', async () => {
+      const result = await service.parseAndComplete(
+        'revisium://localhost:9222/admin/hello/master',
+        'api',
+        { noAuth: true },
+      );
+
+      expect(result.auth.method).toBe('none');
+      expect(interactiveService.promptSelect).not.toHaveBeenCalled();
+      expect(interactiveService.promptPassword).not.toHaveBeenCalled();
+    });
+
     it('uses env credentials when not in URL', async () => {
       interactiveService.promptText.mockImplementation((message: string) => {
         if (message.includes('organization')) return Promise.resolve('org');

--- a/src/services/url/url-builder.service.ts
+++ b/src/services/url/url-builder.service.ts
@@ -22,7 +22,7 @@ export interface UrlEnvConfig {
   username?: string;
   password?: string;
   /** When true, skip auth resolution entirely and treat the target as
-   *  unauthenticated. Used by `--no-auth` against a no-auth standalone. */
+   *  unauthenticated. Used by `--skip-auth` against a no-auth standalone. */
   noAuth?: boolean;
 }
 

--- a/src/services/url/url-builder.service.ts
+++ b/src/services/url/url-builder.service.ts
@@ -21,6 +21,9 @@ export interface UrlEnvConfig {
   apikey?: string;
   username?: string;
   password?: string;
+  /** When true, skip auth resolution entirely and treat the target as
+   *  unauthenticated. Used by `--no-auth` against a no-auth standalone. */
+  noAuth?: boolean;
 }
 
 const DEFAULT_HTTP_PORT = 8080;
@@ -143,6 +146,10 @@ export class UrlBuilderService {
     label: string,
     baseUrl: string,
   ): Promise<AuthCredentials> {
+    if (env?.noAuth) {
+      return { method: 'none' };
+    }
+
     const token = parsed.token || env?.token;
     if (token) {
       return { method: 'token', token };


### PR DESCRIPTION
Three issues from the alpha.3 quickstart, all reproduced locally before pushing.

## 1. Wrong REST endpoint URL in docs

The README and `docs/quickstart.md` showed
`/endpoint/rest/<org>/<project>/<branch>/<rev>/<table>/<rowId>` — the actual
path is `/endpoint/rest/<org>/<project>/<branch>/<rev>/tables/<table>/row/<rowId>`.
Fixed both, plus a one-liner explaining the base/tables/row layout.

## 2. `example bootstrap` double-prompt for credentials

Reproduced: `bootstrapExample` resolved a client up front, then
`ensureProject` re-resolved another internally, so the auth prompt fired
twice. Pass the already-resolved client into `ensureProject` and skip the
second resolution. New unit test asserts `connectionService.resolveTarget`
fires exactly once per bootstrap.

## 3. No way to use no-auth standalone with raw `--url`

Reproduced: `npx @revisium/standalone` (no `--auth` flag) accepts
unauthenticated requests, but the CLI assumed auth was required and
prompted (or failed in non-TTY). The `authMode: 'none'` escape hatch
only existed via workspace context. Added `--skip-auth` on `BaseCommand`
that flows through `ConnectionOptions` -> `UrlEnvConfig.noAuth` ->
`UrlBuilderService.resolveAuth`, which short-circuits to `{ method: 'none' }`
before the prompt. Renamed from `--no-auth` because Commander.js parses
`--no-*` as the negation form of an existing flag and never calls our
parser. New unit test on the URL builder covers the path.

## Quickstart now reads

```bash
npx -y @revisium/standalone
curl -O https://raw.githubusercontent.com/.../examples/quickstart/bootstrap.config.json
revisium example bootstrap --config ./bootstrap.config.json --url revisium://localhost:9222/admin/hello/master --skip-auth --commit
curl http://localhost:9222/endpoint/rest/admin/hello/master/draft/tables/Note/row/first
```

## Validation

- `npm run tsc` clean
- `npm run lint:ci` clean
- `npm test -- --runInBand` -> 346/346
- `npm run build` succeeded
- End-to-end: booted standalone, ran the four-command quickstart non-interactively, curl returned the row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --skip-auth flag to the bootstrap flow to bypass interactive auth for local no-auth instances.

* **Documentation**
  * Updated Quickstart and README to show the new --skip-auth usage, corrected bootstrap command order, clarified REST endpoint paths, and expanded example response metadata.

* **Tests**
  * Added tests ensuring single connection resolution and proper no-auth behavior during URL/connection handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-cli/pull/85)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->