### PR TITLE
feat(auth): expose No Auth as a fourth picker option

### DIFF
--- a/e2e/matrix/M13-no-auth-mode.e2e-spec.ts
+++ b/e2e/matrix/M13-no-auth-mode.e2e-spec.ts
@@ -84,6 +84,64 @@ describe('M13 — authMode none', () => {
     expect(result.exitCode).not.toBe(0);
   });
 
+  it('example bootstrap with --skip-auth + raw --url works without workspace context', async () => {
+    const workspace = newWorkspace();
+    const project = `m13-skipauth-${Date.now()}`;
+    const configPath = `${workspace}/bootstrap.config.json`;
+    const fs = await import('node:fs');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        projectName: project,
+        endpoints: ['REST_API'],
+        tables: [],
+        rows: [],
+      }),
+      'utf-8',
+    );
+    const url = `${standalone.baseUrl.replace(/^https?:\/\//, 'revisium://')}/admin/${project}/master`;
+    const result = await runCli(
+      [
+        'example',
+        'bootstrap',
+        '--config',
+        configPath,
+        '--url',
+        url,
+        '--skip-auth',
+        '--json',
+      ],
+      { cwd: workspace, env: buildEnv(), timeout: 120_000 },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('example bootstrap without --skip-auth against a no-auth standalone fails because stdin is not a TTY', async () => {
+    const workspace = newWorkspace();
+    const project = `m13-noskip-${Date.now()}`;
+    const configPath = `${workspace}/bootstrap.config.json`;
+    const fs = await import('node:fs');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        projectName: project,
+        endpoints: ['REST_API'],
+        tables: [],
+        rows: [],
+      }),
+      'utf-8',
+    );
+    const url = `${standalone.baseUrl.replace(/^https?:\/\//, 'revisium://')}/admin/${project}/master`;
+    const result = await runCli(
+      ['example', 'bootstrap', '--config', configPath, '--url', url, '--json'],
+      { cwd: workspace, env: buildEnv(), timeout: 60_000 },
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(
+      /No credentials found and stdin is not a TTY/,
+    );
+  });
+
   it('example bootstrap works without any credential', async () => {
     const workspace = newWorkspace();
     const project = `m13-bootstrap-${Date.now()}`;

--- a/src/services/url/__tests__/auth-prompt.service.spec.ts
+++ b/src/services/url/__tests__/auth-prompt.service.spec.ts
@@ -39,4 +39,24 @@ describe('AuthPromptService', () => {
     expect(interactive.promptPassword).not.toHaveBeenCalled();
     expect(interactive.promptText).not.toHaveBeenCalled();
   });
+
+  it('offers a No Auth choice that returns method "none" without prompting for secrets', async () => {
+    Object.assign(process.stdin, { isTTY: true });
+    interactive.promptSelect.mockResolvedValue('none');
+
+    const result = await service.promptForAuth('api', 'http://localhost:9222');
+
+    expect(result).toEqual({ method: 'none' });
+    expect(interactive.promptSelect).toHaveBeenCalledTimes(1);
+    const firstCall = interactive.promptSelect.mock.calls[0] as [
+      string,
+      Array<{ name: string; value: string }>,
+    ];
+    const options = firstCall[1];
+    const noAuth = options.find((o) => o.value === 'none');
+    expect(noAuth).toBeDefined();
+    expect(noAuth?.name).toMatch(/No Auth/i);
+    expect(interactive.promptPassword).not.toHaveBeenCalled();
+    expect(interactive.promptText).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/url/auth-prompt.service.ts
+++ b/src/services/url/auth-prompt.service.ts
@@ -31,6 +31,10 @@ export class AuthPromptService {
         { name: `Token (copy from ${tokenPageUrl})`, value: 'token' },
         { name: 'API Key (for automated access)', value: 'apikey' },
         { name: 'Username & Password', value: 'password' },
+        {
+          name: 'No Auth (target does not require credentials)',
+          value: 'none',
+        },
       ],
     );
 


### PR DESCRIPTION
Follow-up to #85.

Quickstart user reported: running `example bootstrap --url revisium://localhost:9222/... --commit` (no `--skip-auth`) against a no-auth standalone dropped them into the auth picker, which only listed Token / API Key / Username & Password. No way to pick no-auth interactively; only way out was Ctrl-C and re-run with `--skip-auth`.

The wiring was already there — `AuthPromptService` short-circuits to `{ method: 'none' }` if the picker returns 'none', and `UrlBuilderService.resolveAuth` accepts that. The option just wasn't in the list.

## Change

Add the option:

```ts
{ name: 'No Auth (target does not require credentials)', value: 'none' }
```

as the fourth choice in the picker. `--skip-auth` remains the non-interactive escape hatch.

## Tests

- **Unit** (`src/services/url/__tests__/auth-prompt.service.spec.ts`): asserts the picker includes the new option and short-circuits to `{ method: 'none' }` when chosen, without prompting for any secret follow-ups.
- **Matrix M13** (`e2e/matrix/M13-no-auth-mode.e2e-spec.ts`): two new cases
  1. `example bootstrap --skip-auth --url revisium://...admin/<proj>/master` (no workspace context) succeeds — the exact quickstart command in non-interactive mode.
  2. Same command **without** `--skip-auth` and a piped stdin fails with `No credentials found and stdin is not a TTY` rather than hanging on the picker.

The picker change itself can't be driven from the matrix (cli-runner spawns with piped stdin, which trips the TTY guard before the picker runs), but the unit test pins the picker behaviour and the matrix cases guard the non-interactive paths.

## Validation

- `npm run tsc` clean
- `npm run lint:ci` clean
- `npm test` -> 348/348
- `npm run test:e2e:matrix -- --testPathPattern=M13` -> 5/5 (the new cases pass against locally-built CLI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "No Auth" authentication option when prompted for credentials for targets that don't require authentication.
  * The `example bootstrap` command now supports `--skip-auth` flag with `--url` without needing workspace context.

* **Tests**
  * Added test coverage for no-auth authentication flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-cli/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->