### PR TITLE
ci: pin Docker image to the npm version just published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,7 @@ permissions:
 
 jobs:
   build-and-push-image:
-    # TODO: bump to the merge commit on revisium-actions master once
-    # https://github.com/revisium/revisium-actions/pull/12 lands.
-    uses: revisium/revisium-actions/.github/workflows/docker-build.yml@730c5b9b817e5f225853939227107d811cfee18f # feat/docker-build-args
+    uses: revisium/revisium-actions/.github/workflows/docker-build.yml@4faefa5d526b0b3af826d650dae4f77d89ccd087 # v0.3.7
     with:
       image_name: ${{ github.event.repository.name }}
       context: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,18 +2,38 @@ name: Build
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'revisium npm version to install (e.g. 2.5.0-alpha.5)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'revisium npm version to install (without leading v)'
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 permissions:
   contents: read
 
 jobs:
   build-and-push-image:
-    uses: revisium/revisium-actions/.github/workflows/docker-build.yml@184b609dcbc1e23f14021141f29226d4e6a0f1ac # v0.3.6
+    # TODO: bump to the merge commit on revisium-actions master once
+    # https://github.com/revisium/revisium-actions/pull/12 lands.
+    uses: revisium/revisium-actions/.github/workflows/docker-build.yml@730c5b9b817e5f225853939227107d811cfee18f # feat/docker-build-args
     with:
       image_name: ${{ github.event.repository.name }}
       context: .
       dockerfile: Dockerfile
       emit_latest_tag: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      build_args: |
+        REVISIUM_VERSION=${{ inputs.version }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,9 +11,15 @@ jobs:
     outputs:
       version: ${{ steps.extract.outputs.version }}
     steps:
-      - name: Strip leading v from tag
+      - name: Validate tag + strip leading v
         id: extract
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' is not a valid semver tag (expected vMAJOR.MINOR.PATCH[-prerelease][+build])" >&2
+            exit 1
+          fi
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
   publish:
     permissions:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,15 @@ on:
       - 'v*'
 
 jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Strip leading v from tag
+        id: extract
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
   publish:
     permissions:
       contents: write
@@ -22,3 +31,14 @@ jobs:
       create_github_release: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  build-image:
+    needs: [publish, resolve-version]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.resolve-version.outputs.version }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM node:22-alpine
 RUN apk add --no-cache bash ca-certificates curl tini \
   && update-ca-certificates
 
-RUN npm i -g revisium \
+ARG REVISIUM_VERSION
+RUN test -n "${REVISIUM_VERSION}" \
+ && npm i -g "revisium@${REVISIUM_VERSION}" \
  && revisium --version \
- && echo "✅ Installed revisium successfully"
+ && echo "Installed revisium@${REVISIUM_VERSION}"
 
 WORKDIR /app
 RUN mkdir -p /app/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache bash ca-certificates curl tini \
   && update-ca-certificates
 
 ARG REVISIUM_VERSION
-RUN test -n "${REVISIUM_VERSION}" \
+RUN : "${REVISIUM_VERSION:?REVISIUM_VERSION build-arg is required (pass --build-arg REVISIUM_VERSION=<x.y.z>)}" \
  && npm i -g "revisium@${REVISIUM_VERSION}" \
  && revisium --version \
  && echo "Installed revisium@${REVISIUM_VERSION}"


### PR DESCRIPTION
## Why

Today `build.yml` runs `npm i -g revisium` inside the Dockerfile, which resolves the `latest` dist-tag at image-build time. After we cut an alpha, `npm-publish.yml` ships e.g. `2.5.0-alpha.5` to the `alpha` tag, but the Docker image still bakes the previous `latest` (`2.4.0`). For alpha-only releases the image isn't tied to the npm version at all.

We want: same git tag → matching npm package + Docker image.

## What

Three coordinated changes, all on the same tag push:

1. **Dockerfile** — accept `REVISIUM_VERSION` as a build arg and `npm i -g revisium@${REVISIUM_VERSION}`. Hard-fails if the arg is missing, so we can't silently regress to "install latest".

2. **`.github/workflows/build.yml`** — becomes a callable reusable workflow (`on: workflow_call`) with a required `version` input. Passes it through as `build_args: REVISIUM_VERSION=…` to the reusable docker-build workflow. `workflow_dispatch` keeps a `version` input too, for manual rebuilds against an existing npm version.

3. **`.github/workflows/npm-publish.yml`** — adds a tiny `resolve-version` job that strips the leading `v` from `GITHUB_REF_NAME`, and a `build-image` job that `needs: [publish, resolve-version]` and calls `./.github/workflows/build.yml` with that version. The git tag stays the single source of truth.

## Cross-repo

Depends on https://github.com/revisium/revisium-actions/pull/12 which adds a `build_args` input to the reusable `docker-build.yml`. `build.yml` here is temporarily pinned to that PR's branch tip; there's a `TODO` to bump to the merge commit once it lands.

## Order of merge

1. Land revisium-actions#12 (adds the input).
2. Bump the pin in `build.yml` here to the merge commit on `master`.
3. Merge this PR.
4. Next release-train alpha-bump will trigger the new chain end-to-end (publish → build-image with the right version).

## Validation done locally

- `actionlint .github/workflows/*.yml` clean.
- Manual trace of the `needs:` graph: `resolve-version` outputs `version`; `build-image` needs both `publish` (gate) and `resolve-version` (data).
- Dockerfile change is a no-op without the build arg, fail-fast with one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflows updated to accept and forward a version input for reproducible, version-pinned Docker image builds.
  * Automated extraction/validation of release tag version and passing it into image build; Docker Hub credentials forwarded for publishing.
  * Docker image build now requires a specified revisium version at build time and installs that exact CLI release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-cli/pull/87)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->